### PR TITLE
Fix Data Frame `nest()` With Missing Group Values

### DIFF
--- a/cashctrl_ledger/nesting.py
+++ b/cashctrl_ledger/nesting.py
@@ -54,7 +54,7 @@ def nest(df: pd.DataFrame, columns: List[str], key: str = 'data') -> pd.DataFram
         return empty_result
 
     group_columns = [col for col in df.columns if col not in columns]
-    grouped = df.groupby(group_columns)
+    grouped = df.groupby(group_columns, dropna=False)
     nested_dfs = grouped.apply(lambda x: [x[columns].reset_index(drop=True)], include_groups=False)
     result = pd.DataFrame(grouped[group_columns].first())
     result[key] = [df[0] for df in nested_dfs.reset_index(drop=True)]

--- a/tests/test_nest.py
+++ b/tests/test_nest.py
@@ -66,6 +66,25 @@ def test_nest_with_multiple_groups():
     expected_df = pd.DataFrame(expected_data)
     pd.testing.assert_frame_equal(result, expected_df)
 
+def test_nest_with_na_grouping_values():
+    df = pd.DataFrame({
+        'id': [10, 10, None, 16, None],
+        'text': ['hello', 'hello', 'world', 'world', 'world'],
+        'sub_id': [33, 33, 20, 16, 40],
+        'sub_text': ['test1', 'test2', 'test3', 'test4', 'test5']
+    })
+    result = nest(df, columns=['sub_id', 'sub_text'], key='items')
+    expected_df = pd.DataFrame({
+        'id': [10, 16, None],
+        'text': ['hello', 'world', 'world'],
+        'items': [
+            pd.DataFrame({'sub_id': [33, 33], 'sub_text': ['test1', 'test2']}),
+            pd.DataFrame({'sub_id': [16], 'sub_text': ['test4']}),
+            pd.DataFrame({'sub_id': [20, 40], 'sub_text': ['test3', 'test5']})
+        ]
+    })
+    pd.testing.assert_frame_equal(result, expected_df)
+
 def test_successive_nest_and_unnest_results_in_original_df():
     data = {
         'id': [10, 10, 16, 16],


### PR DESCRIPTION
The `nest()` function silently drops rows with missing (NA) group values. See #25.

This PR fixes the problem. It consists of two commits:

1. e553d43ca1 adds a unit test to check for the expected behaviour in presence of missing (NA) group values. 
Failure of this new test confirms the reported bug. See ...

1. 14911bf8bc Implements the expected behaviour in presence of missing (NA) group values and thereby fixes # 25.
The test added above now passes, confirming the `nest()` function behaves as expected.

