### PR TITLE
Feat/create non existent account groups

### DIFF
--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -136,7 +136,7 @@ class CashCtrlLedger(LedgerEngine):
         # Update account categories
         def get_nodes_list(path: str) -> List[str]:
             parts = path.strip('/').split('/')
-            return ['/' + '/'.join(parts[:i]) for i in range(1, len(parts) + 1)]
+            return ['/' + '/'.join(parts[:i]) for i in range(1, len(parts) + 1)][1:]
         def account_groups(df: pd.DataFrame) -> Dict[str, str]:
             df['nodes'] = [pd.DataFrame({'items': get_nodes_list(path)}) for path in df['group']]
             df = unnest(df, key='nodes')

--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -140,7 +140,7 @@ class CashCtrlLedger(LedgerEngine):
         def account_groups(df: pd.DataFrame) -> Dict[str, str]:
             df['nodes'] = [pd.DataFrame({'items': get_nodes_list(path)}) for path in df['group']]
             df = unnest(df, key='nodes')
-            return df.groupby('items')['account'].agg(min).to_dict()
+            return df.groupby('items')['account'].agg('min').to_dict()
         self._client.update_categories(resource='account', target=account_groups(target), delete=delete)
 
         for row in to_add.to_dict('records'):

--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -187,6 +187,10 @@ class CashCtrlLedger(LedgerEngine):
         categories = self._client.list_categories('account')
         categories_map = categories.set_index('path')['id'].to_dict()
         if group not in categories_map:
+            # TODO: CashCtrl - 500 Internal Server Error
+            # self._client.update_categories(resource='account', target=[group])
+            # categories = self._client.list_categories('account')
+            # categories_map = categories.set_index('path')['id'].to_dict()
             raise ValueError(f"Group '{group}' does not exist.")
         category_id = categories_map[group]
 

--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -187,11 +187,11 @@ class CashCtrlLedger(LedgerEngine):
         categories = self._client.list_categories('account')
         categories_map = categories.set_index('path')['id'].to_dict()
         if group not in categories_map:
-            # TODO: CashCtrl - 500 Internal Server Error
-            # self._client.update_categories(resource='account', target=[group])
-            # categories = self._client.list_categories('account')
-            # categories_map = categories.set_index('path')['id'].to_dict()
-            raise ValueError(f"Group '{group}' does not exist.")
+            # Find accounts here and find the first number
+            # Or drop error as before
+            self._client.update_categories(resource='account', target=[group])
+            categories = self._client.list_categories('account')
+            categories_map = categories.set_index('path')['id'].to_dict()
         category_id = categories_map[group]
 
         payload = {
@@ -203,6 +203,9 @@ class CashCtrlLedger(LedgerEngine):
         }
 
         self._client.post("account/create.json", data=payload)
+
+        # after post we can use created number to create category
+        # and then update account with right category
 
     def update_account(self, account: str, currency: str, text: str, group: str, vat_code: str | None = None):
         """

--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -141,7 +141,7 @@ class CashCtrlLedger(LedgerEngine):
             df['nodes'] = [pd.DataFrame({'items': get_nodes_list(path)}) for path in df['group']]
             df = unnest(df, key='nodes')
             return df.groupby('items')['account'].agg(min).to_dict()
-        self._client.update_categories(resource='account', target=account_groups(target))
+        self._client.update_categories(resource='account', target=account_groups(target), delete=delete)
 
         for row in to_add.to_dict('records'):
             self.add_account(
@@ -197,9 +197,7 @@ class CashCtrlLedger(LedgerEngine):
         categories = self._client.list_categories('account')
         categories_map = categories.set_index('path')['id'].to_dict()
         if group not in categories_map:
-            self._client.update_categories(resource='account', target={'name': group, 'number': account})
-            categories = self._client.list_categories('account')
-            categories_map = categories.set_index('path')['id'].to_dict()
+            raise ValueError(f"Group '{group}' does not exist.")
         category_id = categories_map[group]
 
         payload = {

--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -136,7 +136,9 @@ class CashCtrlLedger(LedgerEngine):
         # Update account categories
         def get_nodes_list(path: str) -> List[str]:
             parts = path.strip('/').split('/')
-            return ['/' + '/'.join(parts[:i]) for i in range(1, len(parts) + 1)][1:]
+            paths = ['/' + '/'.join(parts[:i]) for i in range(1, len(parts) + 1)]
+            # Ignore root nodes, as account category root nodes are immutable in CashCtrl
+            return paths[1:]
         def account_groups(df: pd.DataFrame) -> Dict[str, str]:
             df['nodes'] = [pd.DataFrame({'items': get_nodes_list(path)}) for path in df['group']]
             df = unnest(df, key='nodes')

--- a/tests/test_account_chart.py
+++ b/tests/test_account_chart.py
@@ -44,7 +44,7 @@ def test_account_mutators(add_and_delete_vat_code):
         'currency': 'CHF',
         'text': 'test create account',
         'vat_code': 'TestCodeAccounts',
-        'group': '/Anlagevermögen'
+        'group': '/Assets/Anlagevermögen'
     }
     cashctrl_ledger.add_account(**new_account)
     updated_accounts = cashctrl_ledger.account_chart().reset_index()
@@ -66,7 +66,7 @@ def test_account_mutators(add_and_delete_vat_code):
         'currency': 'CHF',
         'text': 'test create account',
         'vat_code': None,
-        'group': '/Anlagevermögen'
+        'group': '/Assets/Anlagevermögen'
     }
     cashctrl_ledger.add_account(**new_account)
     updated_accounts = cashctrl_ledger.account_chart().reset_index()
@@ -88,7 +88,7 @@ def test_account_mutators(add_and_delete_vat_code):
         'currency': 'CHF',
         'text': 'test update account',
         'vat_code': 'TestCodeAccounts',
-        'group': '/Anlagevermögen'
+        'group': '/Assets/Anlagevermögen'
     }
     cashctrl_ledger.update_account(**new_account)
     updated_accounts = cashctrl_ledger.account_chart().reset_index()
@@ -110,7 +110,7 @@ def test_account_mutators(add_and_delete_vat_code):
         'currency': 'USD',
         'text': 'test update account without VAT',
         'vat_code': None,
-        'group': '/Anlagevermögen'
+        'group': '/Assets/Anlagevermögen'
     }
     cashctrl_ledger.update_account(**new_account)
     updated_accounts = cashctrl_ledger.account_chart().reset_index()
@@ -147,7 +147,7 @@ def test_add_pre_existing_account_raise_error():
     cashctrl_ledger = CashCtrlLedger()
     with pytest.raises(requests.exceptions.RequestException):
         cashctrl_ledger.add_account(account=1200, currency='EUR',
-            text='test account', vat_code=None, group='/Anlagevermögen'
+            text='test account', vat_code=None, group='/Assets/Anlagevermögen'
         )
 
 # Test adding an account with invalid currency should raise an error.
@@ -155,7 +155,7 @@ def test_add_account_with_invalid_currency_error():
     cashctrl_ledger = CashCtrlLedger()
     with pytest.raises(ValueError):
         cashctrl_ledger.add_account(account=1142, currency='',
-            text='test account', vat_code=None, group='/Anlagevermögen'
+            text='test account', vat_code=None, group='/Assets/Anlagevermögen'
         )
 
 # Test adding an account with invalid VAT code should raise an error.
@@ -163,7 +163,7 @@ def test_add_account_with_invalid_vat_raise_error():
     cashctrl_ledger = CashCtrlLedger()
     with pytest.raises(ValueError):
         cashctrl_ledger.update_account(account=1143, currency='USD',
-            text='test account', vat_code='Non-Existing Tax Code', group='/Anlagevermögen'
+            text='test account', vat_code='Non-Existing Tax Code', group='/Assets/Anlagevermögen'
         )
 
 # Test adding an account with invalid group should raise an error.
@@ -171,7 +171,7 @@ def test_add_account_with_invalid_group_raise_error():
     cashctrl_ledger = CashCtrlLedger()
     with pytest.raises(ValueError):
         cashctrl_ledger.add_account(account=999999, currency='USD',
-            text='test account', vat_code='MwSt. 2.6%', group='Anlagevermögen/ABC'
+            text='test account', vat_code='MwSt. 2.6%', group='/Assets/Anlagevermögen/ABC'
         )
 
 
@@ -180,7 +180,7 @@ def test_update_non_existing_account_raise_error():
     cashctrl_ledger = CashCtrlLedger()
     with pytest.raises(ValueError):
         cashctrl_ledger.update_account(account=1147, currency='CHF',
-            text='test account', vat_code='MwSt. 2.6%', group='/Anlagevermögen'
+            text='test account', vat_code='MwSt. 2.6%', group='/Assets/Anlagevermögen'
         )
 
 # Test updating an account with invalid currency should raise an error.
@@ -188,7 +188,7 @@ def test_update_account_with_invalid_currency_error():
     cashctrl_ledger = CashCtrlLedger()
     with pytest.raises(ValueError):
         cashctrl_ledger.update_account(account=1148, currency='not-existing-currency',
-            text='test account', vat_code=None, group='/Anlagevermögen'
+            text='test account', vat_code=None, group='/Assets/Anlagevermögen'
         )
 
 # Test updating an account with invalid VAT code should raise an error.
@@ -196,7 +196,7 @@ def test_update_account_with_invalid_vat_raise_error():
     cashctrl_ledger = CashCtrlLedger()
     with pytest.raises(ValueError):
         cashctrl_ledger.update_account(account=1149, currency='USD',
-            text='test create account', vat_code='Non-Existing Tax Code', group='/Anlagevermögen'
+            text='test create account', vat_code='Non-Existing Tax Code', group='/Assets/Anlagevermögen'
         )
 
 # Test updating an account with invalid group should raise an error.
@@ -217,7 +217,7 @@ def test_mirror_accounts(add_and_delete_vat_code):
         "currency": ["CHF"],
         "text": ["2test_account_api_added"],
         "vat_code": ["TestCodeAccounts"],
-        "group": ["/Anlagevermögen/xyz"],
+        "group": ["/Assets/Anlagevermögen/xyz"],
     })
     target_df = pd.concat([account, initial_accounts])
 

--- a/tests/test_account_chart.py
+++ b/tests/test_account_chart.py
@@ -169,9 +169,10 @@ def add_and_delete_vat_code():
 # # Test adding an account with invalid group should raise an error.
 # def test_add_account_with_invalid_group_raise_error():
 #     cashctrl_ledger = CashCtrlLedger()
-#     cashctrl_ledger.add_account(account=999999, currency='USD',
-#         text='test account', vat_code='MwSt. 2.6%', group='Anlagevermögen/ABC'
-#     )
+#     with pytest.raises(ValueError):
+#         cashctrl_ledger.add_account(account=999999, currency='USD',
+#             text='test account', vat_code='MwSt. 2.6%', group='Anlagevermögen/ABC'
+#         )
 
 
 # # Test updating a non existing account should raise an error.
@@ -207,7 +208,7 @@ def add_and_delete_vat_code():
 #         )
 
 # Tests the mirroring functionality of accounts.
-def test_mirror_accounts():
+def test_mirror_accounts(add_and_delete_vat_code):
     cashctrl_ledger = CashCtrlLedger()
     initial_accounts = cashctrl_ledger.account_chart().reset_index()
 
@@ -222,36 +223,36 @@ def test_mirror_accounts():
 
     # Mirror test accounts onto server with delete=False
     cashctrl_ledger.mirror_account_chart(target_df, delete=False)
-    # mirrored_df = cashctrl_ledger.account_chart().reset_index()
-    # m = target_df.merge(mirrored_df, how='left', indicator=True)
-    # assert (m['_merge'] == 'both').all(), (
-    #         'Mirroring error: Some target accounts were not mirrored'
-    #     )
+    mirrored_df = cashctrl_ledger.account_chart().reset_index()
+    m = target_df.merge(mirrored_df, how='left', indicator=True)
+    assert (m['_merge'] == 'both').all(), (
+            'Mirroring error: Some target accounts were not mirrored'
+        )
 
-    # # Mirror target accounts onto server with delete=True
-    # cashctrl_ledger.mirror_account_chart(target_df, delete=True)
-    # mirrored_df = cashctrl_ledger.account_chart().reset_index()
-    # m = target_df.merge(mirrored_df, how='outer', indicator=True)
-    # assert (m['_merge'] == 'both').all(), (
-    #         'Mirroring error: Some target accounts were not mirrored'
-    #     )
+    # Mirror target accounts onto server with delete=True
+    cashctrl_ledger.mirror_account_chart(target_df, delete=True)
+    mirrored_df = cashctrl_ledger.account_chart().reset_index()
+    m = target_df.merge(mirrored_df, how='outer', indicator=True)
+    assert (m['_merge'] == 'both').all(), (
+            'Mirroring error: Some target accounts were not mirrored'
+        )
 
-    # # Reshuffle target data randomly
-    # target_df = target_df.sample(frac=1).reset_index(drop=True)
+    # Reshuffle target data randomly
+    target_df = target_df.sample(frac=1).reset_index(drop=True)
 
-    # # Mirror target accounts onto server with updating
-    # target_df.loc[target_df['account'] == 2, 'text'] = "New_Test_Text"
-    # cashctrl_ledger.mirror_account_chart(target_df, delete=True)
-    # mirrored_df = cashctrl_ledger.account_chart().reset_index()
-    # m = target_df.merge(mirrored_df, how='outer', indicator=True)
-    # assert (m['_merge'] == 'both').all(), (
-    #         'Mirroring error: Some target accounts were not mirrored'
-    #     )
+    # Mirror target accounts onto server with updating
+    target_df.loc[target_df['account'] == 2, 'text'] = "New_Test_Text"
+    cashctrl_ledger.mirror_account_chart(target_df, delete=True)
+    mirrored_df = cashctrl_ledger.account_chart().reset_index()
+    m = target_df.merge(mirrored_df, how='outer', indicator=True)
+    assert (m['_merge'] == 'both').all(), (
+            'Mirroring error: Some target accounts were not mirrored'
+        )
 
-    # # Mirror initial accounts onto server with delete=True to restore original state
-    # cashctrl_ledger.mirror_account_chart(initial_accounts, delete=True)
-    # mirrored_df = cashctrl_ledger.account_chart().reset_index()
-    # m = initial_accounts.merge(mirrored_df, how='outer', indicator=True)
-    # assert (m['_merge'] == 'both').all(), (
-    #         'Mirroring error: Some target accounts were not mirrored'
-    #     )
+    # Mirror initial accounts onto server with delete=True to restore original state
+    cashctrl_ledger.mirror_account_chart(initial_accounts, delete=True)
+    mirrored_df = cashctrl_ledger.account_chart().reset_index()
+    m = initial_accounts.merge(mirrored_df, how='outer', indicator=True)
+    assert (m['_merge'] == 'both').all(), (
+            'Mirroring error: Some target accounts were not mirrored'
+        )

--- a/tests/test_account_chart.py
+++ b/tests/test_account_chart.py
@@ -27,185 +27,185 @@ def add_and_delete_vat_code():
     # Deletes VAT code
     cashctrl_ledger.delete_vat_code(code="TestCodeAccounts")
 
-# def test_account_mutators(add_and_delete_vat_code):
-#     cashctrl_ledger = CashCtrlLedger()
+def test_account_mutators(add_and_delete_vat_code):
+    cashctrl_ledger = CashCtrlLedger()
 
-#     # Ensure there is no account '1145' or '1146' on the remote system
-#     cashctrl_ledger.delete_account(1145, allow_missing=True)
-#     cashctrl_ledger.delete_account(1146, allow_missing=True)
-#     account_chart = cashctrl_ledger.account_chart()
-#     assert 1145 not in account_chart.index
-#     assert 1146 not in account_chart.index
+    # Ensure there is no account '1145' or '1146' on the remote system
+    cashctrl_ledger.delete_account(1145, allow_missing=True)
+    cashctrl_ledger.delete_account(1146, allow_missing=True)
+    account_chart = cashctrl_ledger.account_chart()
+    assert 1145 not in account_chart.index
+    assert 1146 not in account_chart.index
 
-#     # Test adding an account
-#     initial_accounts = cashctrl_ledger.account_chart().reset_index()
-#     new_account = {
-#         'account': 1145,
-#         'currency': 'CHF',
-#         'text': 'test create account',
-#         'vat_code': 'TestCodeAccounts',
-#         'group': '/Anlagevermögen'
-#     }
-#     cashctrl_ledger.add_account(**new_account)
-#     updated_accounts = cashctrl_ledger.account_chart().reset_index()
-#     outer_join = pd.merge(initial_accounts, updated_accounts, how='outer', indicator=True)
-#     created_accounts = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1)
+    # Test adding an account
+    initial_accounts = cashctrl_ledger.account_chart().reset_index()
+    new_account = {
+        'account': 1145,
+        'currency': 'CHF',
+        'text': 'test create account',
+        'vat_code': 'TestCodeAccounts',
+        'group': '/Anlagevermögen'
+    }
+    cashctrl_ledger.add_account(**new_account)
+    updated_accounts = cashctrl_ledger.account_chart().reset_index()
+    outer_join = pd.merge(initial_accounts, updated_accounts, how='outer', indicator=True)
+    created_accounts = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1)
 
-#     assert len(created_accounts) == 1, "Expected exactly one row to be added"
-#     assert created_accounts['account'].item() == new_account['account']
-#     assert created_accounts['text'].item() == new_account['text']
-#     assert created_accounts['account'].item() == new_account['account']
-#     assert created_accounts['currency'].item() == new_account['currency']
-#     assert created_accounts['vat_code'].item() == 'TestCodeAccounts'
-#     assert created_accounts['group'].item() == new_account['group']
+    assert len(created_accounts) == 1, "Expected exactly one row to be added"
+    assert created_accounts['account'].item() == new_account['account']
+    assert created_accounts['text'].item() == new_account['text']
+    assert created_accounts['account'].item() == new_account['account']
+    assert created_accounts['currency'].item() == new_account['currency']
+    assert created_accounts['vat_code'].item() == 'TestCodeAccounts'
+    assert created_accounts['group'].item() == new_account['group']
 
-#     # Test adding an account without VAT
-#     initial_accounts = cashctrl_ledger.account_chart().reset_index()
-#     new_account = {
-#         'account': 1146,
-#         'currency': 'CHF',
-#         'text': 'test create account',
-#         'vat_code': None,
-#         'group': '/Anlagevermögen'
-#     }
-#     cashctrl_ledger.add_account(**new_account)
-#     updated_accounts = cashctrl_ledger.account_chart().reset_index()
-#     outer_join = pd.merge(initial_accounts, updated_accounts, how='outer', indicator=True)
-#     created_accounts = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1)
+    # Test adding an account without VAT
+    initial_accounts = cashctrl_ledger.account_chart().reset_index()
+    new_account = {
+        'account': 1146,
+        'currency': 'CHF',
+        'text': 'test create account',
+        'vat_code': None,
+        'group': '/Anlagevermögen'
+    }
+    cashctrl_ledger.add_account(**new_account)
+    updated_accounts = cashctrl_ledger.account_chart().reset_index()
+    outer_join = pd.merge(initial_accounts, updated_accounts, how='outer', indicator=True)
+    created_accounts = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1)
 
-#     assert len(created_accounts) == 1, "Expected exactly one row to be added"
-#     assert created_accounts['account'].item() == new_account['account']
-#     assert created_accounts['text'].item() == new_account['text']
-#     assert created_accounts['account'].item() == new_account['account']
-#     assert created_accounts['currency'].item() == new_account['currency']
-#     assert pd.isna(created_accounts['vat_code'].item())
-#     assert created_accounts['group'].item() == new_account['group']
+    assert len(created_accounts) == 1, "Expected exactly one row to be added"
+    assert created_accounts['account'].item() == new_account['account']
+    assert created_accounts['text'].item() == new_account['text']
+    assert created_accounts['account'].item() == new_account['account']
+    assert created_accounts['currency'].item() == new_account['currency']
+    assert pd.isna(created_accounts['vat_code'].item())
+    assert created_accounts['group'].item() == new_account['group']
 
-#     # Test updating an account.
-#     initial_accounts = cashctrl_ledger.account_chart().reset_index()
-#     new_account = {
-#         'account': 1146,
-#         'currency': 'CHF',
-#         'text': 'test update account',
-#         'vat_code': 'TestCodeAccounts',
-#         'group': '/Anlagevermögen'
-#     }
-#     cashctrl_ledger.update_account(**new_account)
-#     updated_accounts = cashctrl_ledger.account_chart().reset_index()
-#     outer_join = pd.merge(initial_accounts, updated_accounts, how='outer', indicator=True)
-#     modified_accounts = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1)
+    # Test updating an account.
+    initial_accounts = cashctrl_ledger.account_chart().reset_index()
+    new_account = {
+        'account': 1146,
+        'currency': 'CHF',
+        'text': 'test update account',
+        'vat_code': 'TestCodeAccounts',
+        'group': '/Anlagevermögen'
+    }
+    cashctrl_ledger.update_account(**new_account)
+    updated_accounts = cashctrl_ledger.account_chart().reset_index()
+    outer_join = pd.merge(initial_accounts, updated_accounts, how='outer', indicator=True)
+    modified_accounts = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1)
 
-#     assert len(modified_accounts) == 1, "Expected exactly one updated row"
-#     assert modified_accounts['account'].item() == new_account['account']
-#     assert modified_accounts['text'].item() == new_account['text']
-#     assert modified_accounts['account'].item() == new_account['account']
-#     assert modified_accounts['currency'].item() == new_account['currency']
-#     assert modified_accounts['vat_code'].item() == 'TestCodeAccounts'
-#     assert modified_accounts['group'].item() == new_account['group']
+    assert len(modified_accounts) == 1, "Expected exactly one updated row"
+    assert modified_accounts['account'].item() == new_account['account']
+    assert modified_accounts['text'].item() == new_account['text']
+    assert modified_accounts['account'].item() == new_account['account']
+    assert modified_accounts['currency'].item() == new_account['currency']
+    assert modified_accounts['vat_code'].item() == 'TestCodeAccounts'
+    assert modified_accounts['group'].item() == new_account['group']
 
-#     # Test updating an account without VAT code.
-#     initial_accounts = cashctrl_ledger.account_chart().reset_index()
-#     new_account = {
-#         'account': 1145,
-#         'currency': 'USD',
-#         'text': 'test update account without VAT',
-#         'vat_code': None,
-#         'group': '/Anlagevermögen'
-#     }
-#     cashctrl_ledger.update_account(**new_account)
-#     updated_accounts = cashctrl_ledger.account_chart().reset_index()
-#     outer_join = pd.merge(initial_accounts, updated_accounts, how='outer', indicator=True)
-#     created_accounts = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1)
+    # Test updating an account without VAT code.
+    initial_accounts = cashctrl_ledger.account_chart().reset_index()
+    new_account = {
+        'account': 1145,
+        'currency': 'USD',
+        'text': 'test update account without VAT',
+        'vat_code': None,
+        'group': '/Anlagevermögen'
+    }
+    cashctrl_ledger.update_account(**new_account)
+    updated_accounts = cashctrl_ledger.account_chart().reset_index()
+    outer_join = pd.merge(initial_accounts, updated_accounts, how='outer', indicator=True)
+    created_accounts = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1)
 
-#     assert len(created_accounts) == 1, "Expected exactly one row to be added"
-#     assert created_accounts['account'].item() == new_account['account']
-#     assert created_accounts['text'].item() == new_account['text']
-#     assert created_accounts['account'].item() == new_account['account']
-#     assert created_accounts['currency'].item() == new_account['currency']
-#     assert pd.isna(created_accounts['vat_code'].item())
-#     assert created_accounts['group'].item() == new_account['group']
+    assert len(created_accounts) == 1, "Expected exactly one row to be added"
+    assert created_accounts['account'].item() == new_account['account']
+    assert created_accounts['text'].item() == new_account['text']
+    assert created_accounts['account'].item() == new_account['account']
+    assert created_accounts['currency'].item() == new_account['currency']
+    assert pd.isna(created_accounts['vat_code'].item())
+    assert created_accounts['group'].item() == new_account['group']
 
-#     # Test deleting the accounts added above.
-#     cashctrl_ledger = CashCtrlLedger()
-#     cashctrl_ledger.delete_account(account=1145)
-#     cashctrl_ledger.delete_account(account=1146)
-#     updated_accounts = cashctrl_ledger.account_chart()
-#     assert 1145 not in updated_accounts.index
-#     assert 1146 not in updated_accounts.index
+    # Test deleting the accounts added above.
+    cashctrl_ledger = CashCtrlLedger()
+    cashctrl_ledger.delete_account(account=1145)
+    cashctrl_ledger.delete_account(account=1146)
+    updated_accounts = cashctrl_ledger.account_chart()
+    assert 1145 not in updated_accounts.index
+    assert 1146 not in updated_accounts.index
 
-# # Test deleting a non existent account should raise an error.
-# def test_delete_non_existing_account_raise_error():
-#     cashctrl_ledger = CashCtrlLedger()
-#     # Ensure there is no account '1141'
-#     cashctrl_ledger.delete_account(1141, allow_missing=True)
-#     assert 1141 not in cashctrl_ledger.account_chart().index
-#     with pytest.raises(ValueError):
-#         cashctrl_ledger.delete_account(1141)
+# Test deleting a non existent account should raise an error.
+def test_delete_non_existing_account_raise_error():
+    cashctrl_ledger = CashCtrlLedger()
+    # Ensure there is no account '1141'
+    cashctrl_ledger.delete_account(1141, allow_missing=True)
+    assert 1141 not in cashctrl_ledger.account_chart().index
+    with pytest.raises(ValueError):
+        cashctrl_ledger.delete_account(1141)
 
-# # Test adding an already existing account should raise an error.
-# def test_add_pre_existing_account_raise_error():
-#     cashctrl_ledger = CashCtrlLedger()
-#     with pytest.raises(requests.exceptions.RequestException):
-#         cashctrl_ledger.add_account(account=1200, currency='EUR',
-#             text='test account', vat_code=None, group='/Anlagevermögen'
-#         )
+# Test adding an already existing account should raise an error.
+def test_add_pre_existing_account_raise_error():
+    cashctrl_ledger = CashCtrlLedger()
+    with pytest.raises(requests.exceptions.RequestException):
+        cashctrl_ledger.add_account(account=1200, currency='EUR',
+            text='test account', vat_code=None, group='/Anlagevermögen'
+        )
 
-# # Test adding an account with invalid currency should raise an error.
-# def test_add_account_with_invalid_currency_error():
-#     cashctrl_ledger = CashCtrlLedger()
-#     with pytest.raises(ValueError):
-#         cashctrl_ledger.add_account(account=1142, currency='',
-#             text='test account', vat_code=None, group='/Anlagevermögen'
-#         )
+# Test adding an account with invalid currency should raise an error.
+def test_add_account_with_invalid_currency_error():
+    cashctrl_ledger = CashCtrlLedger()
+    with pytest.raises(ValueError):
+        cashctrl_ledger.add_account(account=1142, currency='',
+            text='test account', vat_code=None, group='/Anlagevermögen'
+        )
 
-# # Test adding an account with invalid VAT code should raise an error.
-# def test_add_account_with_invalid_vat_raise_error():
-#     cashctrl_ledger = CashCtrlLedger()
-#     with pytest.raises(ValueError):
-#         cashctrl_ledger.update_account(account=1143, currency='USD',
-#             text='test account', vat_code='Non-Existing Tax Code', group='/Anlagevermögen'
-#         )
+# Test adding an account with invalid VAT code should raise an error.
+def test_add_account_with_invalid_vat_raise_error():
+    cashctrl_ledger = CashCtrlLedger()
+    with pytest.raises(ValueError):
+        cashctrl_ledger.update_account(account=1143, currency='USD',
+            text='test account', vat_code='Non-Existing Tax Code', group='/Anlagevermögen'
+        )
 
-# # Test adding an account with invalid group should raise an error.
-# def test_add_account_with_invalid_group_raise_error():
-#     cashctrl_ledger = CashCtrlLedger()
-#     with pytest.raises(ValueError):
-#         cashctrl_ledger.add_account(account=999999, currency='USD',
-#             text='test account', vat_code='MwSt. 2.6%', group='Anlagevermögen/ABC'
-#         )
+# Test adding an account with invalid group should raise an error.
+def test_add_account_with_invalid_group_raise_error():
+    cashctrl_ledger = CashCtrlLedger()
+    with pytest.raises(ValueError):
+        cashctrl_ledger.add_account(account=999999, currency='USD',
+            text='test account', vat_code='MwSt. 2.6%', group='Anlagevermögen/ABC'
+        )
 
 
-# # Test updating a non existing account should raise an error.
-# def test_update_non_existing_account_raise_error():
-#     cashctrl_ledger = CashCtrlLedger()
-#     with pytest.raises(ValueError):
-#         cashctrl_ledger.update_account(account=1147, currency='CHF',
-#             text='test account', vat_code='MwSt. 2.6%', group='/Anlagevermögen'
-#         )
+# Test updating a non existing account should raise an error.
+def test_update_non_existing_account_raise_error():
+    cashctrl_ledger = CashCtrlLedger()
+    with pytest.raises(ValueError):
+        cashctrl_ledger.update_account(account=1147, currency='CHF',
+            text='test account', vat_code='MwSt. 2.6%', group='/Anlagevermögen'
+        )
 
-# # Test updating an account with invalid currency should raise an error.
-# def test_update_account_with_invalid_currency_error():
-#     cashctrl_ledger = CashCtrlLedger()
-#     with pytest.raises(ValueError):
-#         cashctrl_ledger.update_account(account=1148, currency='not-existing-currency',
-#             text='test account', vat_code=None, group='/Anlagevermögen'
-#         )
+# Test updating an account with invalid currency should raise an error.
+def test_update_account_with_invalid_currency_error():
+    cashctrl_ledger = CashCtrlLedger()
+    with pytest.raises(ValueError):
+        cashctrl_ledger.update_account(account=1148, currency='not-existing-currency',
+            text='test account', vat_code=None, group='/Anlagevermögen'
+        )
 
-# # Test updating an account with invalid VAT code should raise an error.
-# def test_update_account_with_invalid_vat_raise_error():
-#     cashctrl_ledger = CashCtrlLedger()
-#     with pytest.raises(ValueError):
-#         cashctrl_ledger.update_account(account=1149, currency='USD',
-#             text='test create account', vat_code='Non-Existing Tax Code', group='/Anlagevermögen'
-#         )
+# Test updating an account with invalid VAT code should raise an error.
+def test_update_account_with_invalid_vat_raise_error():
+    cashctrl_ledger = CashCtrlLedger()
+    with pytest.raises(ValueError):
+        cashctrl_ledger.update_account(account=1149, currency='USD',
+            text='test create account', vat_code='Non-Existing Tax Code', group='/Anlagevermögen'
+        )
 
-# # Test updating an account with invalid group should raise an error.
-# def test_update_account_with_invalid_group_raise_error():
-#     cashctrl_ledger = CashCtrlLedger()
-#     with pytest.raises(ValueError):
-#         cashctrl_ledger.update_account(account=1149, currency='USD',
-#             text='test create account', vat_code='MwSt. 2.6%', group='/ABC'
-#         )
+# Test updating an account with invalid group should raise an error.
+def test_update_account_with_invalid_group_raise_error():
+    cashctrl_ledger = CashCtrlLedger()
+    with pytest.raises(ValueError):
+        cashctrl_ledger.update_account(account=1149, currency='USD',
+            text='test create account', vat_code='MwSt. 2.6%', group='/ABC'
+        )
 
 # Tests the mirroring functionality of accounts.
 def test_mirror_accounts(add_and_delete_vat_code):

--- a/tests/test_account_chart.py
+++ b/tests/test_account_chart.py
@@ -207,7 +207,7 @@ def add_and_delete_vat_code():
 #         )
 
 # Tests the mirroring functionality of accounts.
-def test_mirror_accounts(add_and_delete_vat_code):
+def test_mirror_accounts():
     cashctrl_ledger = CashCtrlLedger()
     initial_accounts = cashctrl_ledger.account_chart().reset_index()
 
@@ -222,36 +222,36 @@ def test_mirror_accounts(add_and_delete_vat_code):
 
     # Mirror test accounts onto server with delete=False
     cashctrl_ledger.mirror_account_chart(target_df, delete=False)
-    mirrored_df = cashctrl_ledger.account_chart().reset_index()
-    m = target_df.merge(mirrored_df, how='left', indicator=True)
-    assert (m['_merge'] == 'both').all(), (
-            'Mirroring error: Some target accounts were not mirrored'
-        )
+    # mirrored_df = cashctrl_ledger.account_chart().reset_index()
+    # m = target_df.merge(mirrored_df, how='left', indicator=True)
+    # assert (m['_merge'] == 'both').all(), (
+    #         'Mirroring error: Some target accounts were not mirrored'
+    #     )
 
-    # Mirror target accounts onto server with delete=True
-    cashctrl_ledger.mirror_account_chart(target_df, delete=True)
-    mirrored_df = cashctrl_ledger.account_chart().reset_index()
-    m = target_df.merge(mirrored_df, how='outer', indicator=True)
-    assert (m['_merge'] == 'both').all(), (
-            'Mirroring error: Some target accounts were not mirrored'
-        )
+    # # Mirror target accounts onto server with delete=True
+    # cashctrl_ledger.mirror_account_chart(target_df, delete=True)
+    # mirrored_df = cashctrl_ledger.account_chart().reset_index()
+    # m = target_df.merge(mirrored_df, how='outer', indicator=True)
+    # assert (m['_merge'] == 'both').all(), (
+    #         'Mirroring error: Some target accounts were not mirrored'
+    #     )
 
-    # Reshuffle target data randomly
-    target_df = target_df.sample(frac=1).reset_index(drop=True)
+    # # Reshuffle target data randomly
+    # target_df = target_df.sample(frac=1).reset_index(drop=True)
 
-    # Mirror target accounts onto server with updating
-    target_df.loc[target_df['account'] == 2, 'text'] = "New_Test_Text"
-    cashctrl_ledger.mirror_account_chart(target_df, delete=True)
-    mirrored_df = cashctrl_ledger.account_chart().reset_index()
-    m = target_df.merge(mirrored_df, how='outer', indicator=True)
-    assert (m['_merge'] == 'both').all(), (
-            'Mirroring error: Some target accounts were not mirrored'
-        )
+    # # Mirror target accounts onto server with updating
+    # target_df.loc[target_df['account'] == 2, 'text'] = "New_Test_Text"
+    # cashctrl_ledger.mirror_account_chart(target_df, delete=True)
+    # mirrored_df = cashctrl_ledger.account_chart().reset_index()
+    # m = target_df.merge(mirrored_df, how='outer', indicator=True)
+    # assert (m['_merge'] == 'both').all(), (
+    #         'Mirroring error: Some target accounts were not mirrored'
+    #     )
 
-    # Mirror initial accounts onto server with delete=True to restore original state
-    cashctrl_ledger.mirror_account_chart(initial_accounts, delete=True)
-    mirrored_df = cashctrl_ledger.account_chart().reset_index()
-    m = initial_accounts.merge(mirrored_df, how='outer', indicator=True)
-    assert (m['_merge'] == 'both').all(), (
-            'Mirroring error: Some target accounts were not mirrored'
-        )
+    # # Mirror initial accounts onto server with delete=True to restore original state
+    # cashctrl_ledger.mirror_account_chart(initial_accounts, delete=True)
+    # mirrored_df = cashctrl_ledger.account_chart().reset_index()
+    # m = initial_accounts.merge(mirrored_df, how='outer', indicator=True)
+    # assert (m['_merge'] == 'both').all(), (
+    #         'Mirroring error: Some target accounts were not mirrored'
+    #     )

--- a/tests/test_account_chart.py
+++ b/tests/test_account_chart.py
@@ -27,184 +27,184 @@ def add_and_delete_vat_code():
     # Deletes VAT code
     cashctrl_ledger.delete_vat_code(code="TestCodeAccounts")
 
-def test_account_mutators(add_and_delete_vat_code):
-    cashctrl_ledger = CashCtrlLedger()
+# def test_account_mutators(add_and_delete_vat_code):
+#     cashctrl_ledger = CashCtrlLedger()
 
-    # Ensure there is no account '1145' or '1146' on the remote system
-    cashctrl_ledger.delete_account(1145, allow_missing=True)
-    cashctrl_ledger.delete_account(1146, allow_missing=True)
-    account_chart = cashctrl_ledger.account_chart()
-    assert 1145 not in account_chart.index
-    assert 1146 not in account_chart.index
+#     # Ensure there is no account '1145' or '1146' on the remote system
+#     cashctrl_ledger.delete_account(1145, allow_missing=True)
+#     cashctrl_ledger.delete_account(1146, allow_missing=True)
+#     account_chart = cashctrl_ledger.account_chart()
+#     assert 1145 not in account_chart.index
+#     assert 1146 not in account_chart.index
 
-    # Test adding an account
-    initial_accounts = cashctrl_ledger.account_chart().reset_index()
-    new_account = {
-        'account': 1145,
-        'currency': 'CHF',
-        'text': 'test create account',
-        'vat_code': 'TestCodeAccounts',
-        'group': '/Anlagevermögen'
-    }
-    cashctrl_ledger.add_account(**new_account)
-    updated_accounts = cashctrl_ledger.account_chart().reset_index()
-    outer_join = pd.merge(initial_accounts, updated_accounts, how='outer', indicator=True)
-    created_accounts = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1)
+#     # Test adding an account
+#     initial_accounts = cashctrl_ledger.account_chart().reset_index()
+#     new_account = {
+#         'account': 1145,
+#         'currency': 'CHF',
+#         'text': 'test create account',
+#         'vat_code': 'TestCodeAccounts',
+#         'group': '/Anlagevermögen'
+#     }
+#     cashctrl_ledger.add_account(**new_account)
+#     updated_accounts = cashctrl_ledger.account_chart().reset_index()
+#     outer_join = pd.merge(initial_accounts, updated_accounts, how='outer', indicator=True)
+#     created_accounts = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1)
 
-    assert len(created_accounts) == 1, "Expected exactly one row to be added"
-    assert created_accounts['account'].item() == new_account['account']
-    assert created_accounts['text'].item() == new_account['text']
-    assert created_accounts['account'].item() == new_account['account']
-    assert created_accounts['currency'].item() == new_account['currency']
-    assert created_accounts['vat_code'].item() == 'TestCodeAccounts'
-    assert created_accounts['group'].item() == new_account['group']
+#     assert len(created_accounts) == 1, "Expected exactly one row to be added"
+#     assert created_accounts['account'].item() == new_account['account']
+#     assert created_accounts['text'].item() == new_account['text']
+#     assert created_accounts['account'].item() == new_account['account']
+#     assert created_accounts['currency'].item() == new_account['currency']
+#     assert created_accounts['vat_code'].item() == 'TestCodeAccounts'
+#     assert created_accounts['group'].item() == new_account['group']
 
-    # Test adding an account without VAT
-    initial_accounts = cashctrl_ledger.account_chart().reset_index()
-    new_account = {
-        'account': 1146,
-        'currency': 'CHF',
-        'text': 'test create account',
-        'vat_code': None,
-        'group': '/Anlagevermögen'
-    }
-    cashctrl_ledger.add_account(**new_account)
-    updated_accounts = cashctrl_ledger.account_chart().reset_index()
-    outer_join = pd.merge(initial_accounts, updated_accounts, how='outer', indicator=True)
-    created_accounts = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1)
+#     # Test adding an account without VAT
+#     initial_accounts = cashctrl_ledger.account_chart().reset_index()
+#     new_account = {
+#         'account': 1146,
+#         'currency': 'CHF',
+#         'text': 'test create account',
+#         'vat_code': None,
+#         'group': '/Anlagevermögen'
+#     }
+#     cashctrl_ledger.add_account(**new_account)
+#     updated_accounts = cashctrl_ledger.account_chart().reset_index()
+#     outer_join = pd.merge(initial_accounts, updated_accounts, how='outer', indicator=True)
+#     created_accounts = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1)
 
-    assert len(created_accounts) == 1, "Expected exactly one row to be added"
-    assert created_accounts['account'].item() == new_account['account']
-    assert created_accounts['text'].item() == new_account['text']
-    assert created_accounts['account'].item() == new_account['account']
-    assert created_accounts['currency'].item() == new_account['currency']
-    assert pd.isna(created_accounts['vat_code'].item())
-    assert created_accounts['group'].item() == new_account['group']
+#     assert len(created_accounts) == 1, "Expected exactly one row to be added"
+#     assert created_accounts['account'].item() == new_account['account']
+#     assert created_accounts['text'].item() == new_account['text']
+#     assert created_accounts['account'].item() == new_account['account']
+#     assert created_accounts['currency'].item() == new_account['currency']
+#     assert pd.isna(created_accounts['vat_code'].item())
+#     assert created_accounts['group'].item() == new_account['group']
 
-    # Test updating an account.
-    initial_accounts = cashctrl_ledger.account_chart().reset_index()
-    new_account = {
-        'account': 1146,
-        'currency': 'CHF',
-        'text': 'test update account',
-        'vat_code': 'TestCodeAccounts',
-        'group': '/Anlagevermögen'
-    }
-    cashctrl_ledger.update_account(**new_account)
-    updated_accounts = cashctrl_ledger.account_chart().reset_index()
-    outer_join = pd.merge(initial_accounts, updated_accounts, how='outer', indicator=True)
-    modified_accounts = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1)
+#     # Test updating an account.
+#     initial_accounts = cashctrl_ledger.account_chart().reset_index()
+#     new_account = {
+#         'account': 1146,
+#         'currency': 'CHF',
+#         'text': 'test update account',
+#         'vat_code': 'TestCodeAccounts',
+#         'group': '/Anlagevermögen'
+#     }
+#     cashctrl_ledger.update_account(**new_account)
+#     updated_accounts = cashctrl_ledger.account_chart().reset_index()
+#     outer_join = pd.merge(initial_accounts, updated_accounts, how='outer', indicator=True)
+#     modified_accounts = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1)
 
-    assert len(modified_accounts) == 1, "Expected exactly one updated row"
-    assert modified_accounts['account'].item() == new_account['account']
-    assert modified_accounts['text'].item() == new_account['text']
-    assert modified_accounts['account'].item() == new_account['account']
-    assert modified_accounts['currency'].item() == new_account['currency']
-    assert modified_accounts['vat_code'].item() == 'TestCodeAccounts'
-    assert modified_accounts['group'].item() == new_account['group']
+#     assert len(modified_accounts) == 1, "Expected exactly one updated row"
+#     assert modified_accounts['account'].item() == new_account['account']
+#     assert modified_accounts['text'].item() == new_account['text']
+#     assert modified_accounts['account'].item() == new_account['account']
+#     assert modified_accounts['currency'].item() == new_account['currency']
+#     assert modified_accounts['vat_code'].item() == 'TestCodeAccounts'
+#     assert modified_accounts['group'].item() == new_account['group']
 
-    # Test updating an account without VAT code.
-    initial_accounts = cashctrl_ledger.account_chart().reset_index()
-    new_account = {
-        'account': 1145,
-        'currency': 'USD',
-        'text': 'test update account without VAT',
-        'vat_code': None,
-        'group': '/Anlagevermögen'
-    }
-    cashctrl_ledger.update_account(**new_account)
-    updated_accounts = cashctrl_ledger.account_chart().reset_index()
-    outer_join = pd.merge(initial_accounts, updated_accounts, how='outer', indicator=True)
-    created_accounts = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1)
+#     # Test updating an account without VAT code.
+#     initial_accounts = cashctrl_ledger.account_chart().reset_index()
+#     new_account = {
+#         'account': 1145,
+#         'currency': 'USD',
+#         'text': 'test update account without VAT',
+#         'vat_code': None,
+#         'group': '/Anlagevermögen'
+#     }
+#     cashctrl_ledger.update_account(**new_account)
+#     updated_accounts = cashctrl_ledger.account_chart().reset_index()
+#     outer_join = pd.merge(initial_accounts, updated_accounts, how='outer', indicator=True)
+#     created_accounts = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1)
 
-    assert len(created_accounts) == 1, "Expected exactly one row to be added"
-    assert created_accounts['account'].item() == new_account['account']
-    assert created_accounts['text'].item() == new_account['text']
-    assert created_accounts['account'].item() == new_account['account']
-    assert created_accounts['currency'].item() == new_account['currency']
-    assert pd.isna(created_accounts['vat_code'].item())
-    assert created_accounts['group'].item() == new_account['group']
+#     assert len(created_accounts) == 1, "Expected exactly one row to be added"
+#     assert created_accounts['account'].item() == new_account['account']
+#     assert created_accounts['text'].item() == new_account['text']
+#     assert created_accounts['account'].item() == new_account['account']
+#     assert created_accounts['currency'].item() == new_account['currency']
+#     assert pd.isna(created_accounts['vat_code'].item())
+#     assert created_accounts['group'].item() == new_account['group']
 
-    # Test deleting the accounts added above.
-    cashctrl_ledger = CashCtrlLedger()
-    cashctrl_ledger.delete_account(account=1145)
-    cashctrl_ledger.delete_account(account=1146)
-    updated_accounts = cashctrl_ledger.account_chart()
-    assert 1145 not in updated_accounts.index
-    assert 1146 not in updated_accounts.index
+#     # Test deleting the accounts added above.
+#     cashctrl_ledger = CashCtrlLedger()
+#     cashctrl_ledger.delete_account(account=1145)
+#     cashctrl_ledger.delete_account(account=1146)
+#     updated_accounts = cashctrl_ledger.account_chart()
+#     assert 1145 not in updated_accounts.index
+#     assert 1146 not in updated_accounts.index
 
-# Test deleting a non existent account should raise an error.
-def test_delete_non_existing_account_raise_error():
-    cashctrl_ledger = CashCtrlLedger()
-    # Ensure there is no account '1141'
-    cashctrl_ledger.delete_account(1141, allow_missing=True)
-    assert 1141 not in cashctrl_ledger.account_chart().index
-    with pytest.raises(ValueError):
-        cashctrl_ledger.delete_account(1141)
+# # Test deleting a non existent account should raise an error.
+# def test_delete_non_existing_account_raise_error():
+#     cashctrl_ledger = CashCtrlLedger()
+#     # Ensure there is no account '1141'
+#     cashctrl_ledger.delete_account(1141, allow_missing=True)
+#     assert 1141 not in cashctrl_ledger.account_chart().index
+#     with pytest.raises(ValueError):
+#         cashctrl_ledger.delete_account(1141)
 
-# Test adding an already existing account should raise an error.
-def test_add_pre_existing_account_raise_error():
-    cashctrl_ledger = CashCtrlLedger()
-    with pytest.raises(requests.exceptions.RequestException):
-        cashctrl_ledger.add_account(account=1200, currency='EUR',
-            text='test account', vat_code=None, group='/Anlagevermögen'
-        )
+# # Test adding an already existing account should raise an error.
+# def test_add_pre_existing_account_raise_error():
+#     cashctrl_ledger = CashCtrlLedger()
+#     with pytest.raises(requests.exceptions.RequestException):
+#         cashctrl_ledger.add_account(account=1200, currency='EUR',
+#             text='test account', vat_code=None, group='/Anlagevermögen'
+#         )
 
-# Test adding an account with invalid currency should raise an error.
-def test_add_account_with_invalid_currency_error():
-    cashctrl_ledger = CashCtrlLedger()
-    with pytest.raises(ValueError):
-        cashctrl_ledger.add_account(account=1142, currency='',
-            text='test account', vat_code=None, group='/Anlagevermögen'
-        )
+# # Test adding an account with invalid currency should raise an error.
+# def test_add_account_with_invalid_currency_error():
+#     cashctrl_ledger = CashCtrlLedger()
+#     with pytest.raises(ValueError):
+#         cashctrl_ledger.add_account(account=1142, currency='',
+#             text='test account', vat_code=None, group='/Anlagevermögen'
+#         )
 
-# Test adding an account with invalid VAT code should raise an error.
-def test_add_account_with_invalid_vat_raise_error():
-    cashctrl_ledger = CashCtrlLedger()
-    with pytest.raises(ValueError):
-        cashctrl_ledger.update_account(account=1143, currency='USD',
-            text='test account', vat_code='Non-Existing Tax Code', group='/Anlagevermögen'
-        )
+# # Test adding an account with invalid VAT code should raise an error.
+# def test_add_account_with_invalid_vat_raise_error():
+#     cashctrl_ledger = CashCtrlLedger()
+#     with pytest.raises(ValueError):
+#         cashctrl_ledger.update_account(account=1143, currency='USD',
+#             text='test account', vat_code='Non-Existing Tax Code', group='/Anlagevermögen'
+#         )
 
-# Test adding an account with invalid group should raise an error.
-def test_add_account_with_invalid_group_raise_error():
-    cashctrl_ledger = CashCtrlLedger()
-    with pytest.raises(ValueError):
-        cashctrl_ledger.add_account(account=1144, currency='USD',
-            text='test account', vat_code='MwSt. 2.6%', group='/ABC'
-        )
+# # Test adding an account with invalid group should raise an error.
+# def test_add_account_with_invalid_group_raise_error():
+#     cashctrl_ledger = CashCtrlLedger()
+#     cashctrl_ledger.add_account(account=999999, currency='USD',
+#         text='test account', vat_code='MwSt. 2.6%', group='Anlagevermögen/ABC'
+#     )
 
-# Test updating a non existing account should raise an error.
-def test_update_non_existing_account_raise_error():
-    cashctrl_ledger = CashCtrlLedger()
-    with pytest.raises(ValueError):
-        cashctrl_ledger.update_account(account=1147, currency='CHF',
-            text='test account', vat_code='MwSt. 2.6%', group='/Anlagevermögen'
-        )
 
-# Test updating an account with invalid currency should raise an error.
-def test_update_account_with_invalid_currency_error():
-    cashctrl_ledger = CashCtrlLedger()
-    with pytest.raises(ValueError):
-        cashctrl_ledger.update_account(account=1148, currency='not-existing-currency',
-            text='test account', vat_code=None, group='/Anlagevermögen'
-        )
+# # Test updating a non existing account should raise an error.
+# def test_update_non_existing_account_raise_error():
+#     cashctrl_ledger = CashCtrlLedger()
+#     with pytest.raises(ValueError):
+#         cashctrl_ledger.update_account(account=1147, currency='CHF',
+#             text='test account', vat_code='MwSt. 2.6%', group='/Anlagevermögen'
+#         )
 
-# Test updating an account with invalid VAT code should raise an error.
-def test_update_account_with_invalid_vat_raise_error():
-    cashctrl_ledger = CashCtrlLedger()
-    with pytest.raises(ValueError):
-        cashctrl_ledger.update_account(account=1149, currency='USD',
-            text='test create account', vat_code='Non-Existing Tax Code', group='/Anlagevermögen'
-        )
+# # Test updating an account with invalid currency should raise an error.
+# def test_update_account_with_invalid_currency_error():
+#     cashctrl_ledger = CashCtrlLedger()
+#     with pytest.raises(ValueError):
+#         cashctrl_ledger.update_account(account=1148, currency='not-existing-currency',
+#             text='test account', vat_code=None, group='/Anlagevermögen'
+#         )
 
-# Test updating an account with invalid group should raise an error.
-def test_update_account_with_invalid_group_raise_error():
-    cashctrl_ledger = CashCtrlLedger()
-    with pytest.raises(ValueError):
-        cashctrl_ledger.update_account(account=1149, currency='USD',
-            text='test create account', vat_code='MwSt. 2.6%', group='/ABC'
-        )
+# # Test updating an account with invalid VAT code should raise an error.
+# def test_update_account_with_invalid_vat_raise_error():
+#     cashctrl_ledger = CashCtrlLedger()
+#     with pytest.raises(ValueError):
+#         cashctrl_ledger.update_account(account=1149, currency='USD',
+#             text='test create account', vat_code='Non-Existing Tax Code', group='/Anlagevermögen'
+#         )
+
+# # Test updating an account with invalid group should raise an error.
+# def test_update_account_with_invalid_group_raise_error():
+#     cashctrl_ledger = CashCtrlLedger()
+#     with pytest.raises(ValueError):
+#         cashctrl_ledger.update_account(account=1149, currency='USD',
+#             text='test create account', vat_code='MwSt. 2.6%', group='/ABC'
+#         )
 
 # Tests the mirroring functionality of accounts.
 def test_mirror_accounts(add_and_delete_vat_code):
@@ -216,7 +216,7 @@ def test_mirror_accounts(add_and_delete_vat_code):
         "currency": ["CHF"],
         "text": ["2test_account_api_added"],
         "vat_code": ["TestCodeAccounts"],
-        "group": ["/Anlagevermögen"],
+        "group": ["/Anlagevermögen/xyz"],
     })
     target_df = pd.concat([account, initial_accounts])
 


### PR DESCRIPTION
Pull request covers logic when account non existent account groups will be created before creating accounts to be ensured all accounts will have categories. For this we use `update_categories()` that mirrors categories from `target` df to remote system

`Attention!:` Test will give us en error until [PR on cashctrl_api](https://github.com/macxred/cashctrl_api/pull/27) repository is merged

@lasuk Please review the changes and provide feedback or approval for merging.