### PR TITLE
feat: add mappings for ledger() fields

### DIFF
--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -331,6 +331,7 @@ class CashCtrlLedger(LedgerEngine):
             'currency': individual['currencyCode'],
             'text': individual['title'],
             'vat_code': individual['taxName'],
+            'document': individual['reference'],
         })
 
         # Collective ledger entries represent a group of transactions and
@@ -341,6 +342,7 @@ class CashCtrlLedger(LedgerEngine):
                 res = self._client.get("journal/read.json", params={'id': id})['data']
                 return pd.DataFrame({
                     'id': [res['id']],
+                    'document': res['reference'],
                     'date': [pd.to_datetime(res['dateAdded']).date()],
                     'currency': [res['currencyCode']],
                     'rate': [res['currencyRate']],
@@ -356,6 +358,7 @@ class CashCtrlLedger(LedgerEngine):
                 'text': collective['description'],
                 'amount': collective['credit'] - collective['debit'],
                 'vat_code': collective['taxName'],
+                'document': collective['document'],
             })
             result = pd.concat([result, mapped_collective])
 
@@ -380,6 +383,7 @@ class CashCtrlLedger(LedgerEngine):
                 'currencyId': None if pd.isna(entry['currency'].iat[0]) else self._client.currency_to_id(entry['currency'].iat[0]),
                 'title': entry['text'].iat[0],
                 'taxId': None if pd.isna(entry['vat_code'].iat[0]) else self._client.tax_code_to_id(entry['vat_code'].iat[0]),
+                'reference': None if pd.isna(entry['document'].iat[0]) else entry['document'].iat[0],
             }
 
         # Collective ledger entry
@@ -391,13 +395,14 @@ class CashCtrlLedger(LedgerEngine):
             payload = {
                 'dateAdded': entry['date'].iat[0].strftime("%Y-%m-%d"),
                 'currencyId': None if pd.isna(entry['currency'].iat[0]) else self._client.currency_to_id(entry['currency'].iat[0]),
+                'reference': None if pd.isna(entry['document'].iat[0]) else entry['document'].iat[0],
                 'items': [{
                         'dateAdded': entry['date'].iat[0].strftime("%Y-%m-%d"),
                         'accountId': self._client.account_to_id(row['account']),
                         'debit': max(-row['amount'], 0),
                         'credit': max(row['amount'], 0),
                         'taxId': None if pd.isna(row['vat_code']) else self._client.tax_code_to_id(row['vat_code']),
-                        'description': row['text']
+                        'description': row['text'],
                     } for _, row in entry.iterrows()
                 ]
             }
@@ -427,6 +432,7 @@ class CashCtrlLedger(LedgerEngine):
                 'currencyId': None if pd.isna(entry['currency'].iat[0]) else self._client.currency_to_id(entry['currency'].iat[0]),
                 'title': entry['text'].iat[0],
                 'taxId': None if pd.isna(entry['vat_code'].iat[0]) else self._client.tax_code_to_id(entry['vat_code'].iat[0]),
+                'reference': None if pd.isna(entry['document'].iat[0]) else entry['document'].iat[0],
             }
 
         # Collective ledger entry
@@ -441,13 +447,14 @@ class CashCtrlLedger(LedgerEngine):
                 'id': entry['id'].iat[0],
                 'dateAdded': entry['date'].iat[0].strftime("%Y-%m-%d"),
                 'currencyId': None if pd.isna(entry['currency'].iat[0]) else self._client.currency_to_id(entry['currency'].iat[0]),
+                'reference': None if pd.isna(entry['document'].iat[0]) else entry['document'].iat[0],
                 'items': [{
                         'dateAdded': entry['date'].iat[0].strftime("%Y-%m-%d"),
                         'accountId': self._client.account_to_id(row['account']),
                         'credit': max(row['amount'], 0),
                         'debit': max(-row['amount'], 0),
                         'taxId': None if pd.isna(row['vat_code']) else self._client.tax_code_to_id(row['vat_code']),
-                        'description': row['text']
+                        'description': row['text'],
                     } for _, row in entry.iterrows()
                 ]
             }

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -31,6 +31,7 @@ individual_transaction = pd.DataFrame({
     'currency': ['USD'],
     'text': ['pytest added ledger112'],
     'vat_code': ['Test_VAT_code'],
+    'document': ['document.pdf'],
 })
 collective_transaction = pd.DataFrame({
     'id': ['2', '2'],
@@ -39,7 +40,8 @@ collective_transaction = pd.DataFrame({
     'amount': [-100, 100],
     'currency': ['USD', 'USD'],
     'text': ['pytest added ledger111', 'pytest added ledger222'],
-    'vat_code': ['Test_VAT_code', 'Test_VAT_code']
+    'vat_code': ['Test_VAT_code', 'Test_VAT_code'],
+    'document': ['document-col.pdf', 'document-col.pdf'],
 })
 alt_collective_transaction = pd.DataFrame({
     'id': ['3', '3'],
@@ -48,7 +50,8 @@ alt_collective_transaction = pd.DataFrame({
     'amount': [-200, 200],
     'currency': ['USD', 'USD'],
     'text': ['pytest added alt ledger 1', 'pytest added alt ledger 2'],
-    'vat_code': ['Test_VAT_code', 'Test_VAT_code']
+    'vat_code': ['Test_VAT_code', 'Test_VAT_code'],
+    'document': ['document-col-alt.pdf', 'document-col-alt.pdf'],
 })
 alt_individual_transaction = pd.DataFrame({
     'id': ['4'],
@@ -59,6 +62,7 @@ alt_individual_transaction = pd.DataFrame({
     'currency': ['USD'],
     'text': ['pytest added alt single ledger'],
     'vat_code': ['Test_VAT_code'],
+    'document': ['document-alt.pdf'],
 })
 
 def txn_to_str(df: pd.DataFrame) -> List[str]:
@@ -114,7 +118,7 @@ def test_ledger_accessor_mutators_single_transaction(add_vat_code):
     new_entry['vat_code'] = None
     cashctrl_ledger.update_ledger_entry(entry=new_entry)
 
-    # Test replace with an individual ledger entry
+    # Test replace with an collective ledger entry
     initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
     new_entry = collective_transaction.copy()
     new_entry['id'] = created['id'].iat[0]


### PR DESCRIPTION
This pull request covers changes to include new fields for ledger entry:

Left (`ledger`) -> right (`cashctrl`)

- `base_currency_amount` -> `amount` * `currencyRate`
- `document` -> `reference`

@lasuk Please review the changes and provide feedback or approval for merging.