### PR TITLE
Test creating accounts in top-level category

### DIFF
--- a/tests/test_account_chart.py
+++ b/tests/test_account_chart.py
@@ -211,11 +211,11 @@ def test_mirror_accounts(add_and_delete_vat_code):
     initial_accounts = cashctrl_ledger.account_chart().reset_index()
 
     account = pd.DataFrame({
-        "account": [2],
-        "currency": ["CHF"],
-        "text": ["2test_account_api_added"],
-        "vat_code": ["TestCodeAccounts"],
-        "group": ["/Assets/Anlagevermögen/xyz"],
+        "account": [1, 2],
+        "currency": ["CHF", "EUR"],
+        "text": ["Test Account 1", "Test Account 2"],
+        "vat_code": ["TestCodeAccounts", None],
+        "group": ["/Assets", "/Assets/Anlagevermögen/xyz"],
     })
     target_df = pd.concat([account, initial_accounts])
 


### PR DESCRIPTION
Extend test coverage such that the test fails when encountering issue #39, when accounts are assigned to a top-level account group, such as `/Assets` or `/Liabilities`. 

- The underlying issue is fixed in macxred/cashctrl_api#31.
- We expect the test to fail until  macxred/cashctrl_api#31 is merged.