### PR TITLE
feat: activate ignore_account_root_nodes option

### DIFF
--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -135,14 +135,15 @@ class CashCtrlLedger(LedgerEngine):
         # Update account categories
         def get_nodes_list(path: str) -> List[str]:
             parts = path.strip('/').split('/')
-            paths = ['/' + '/'.join(parts[:i]) for i in range(1, len(parts) + 1)]
-            # Ignore root nodes, as account category root nodes are immutable in CashCtrl
-            return paths[1:]
+            return ['/' + '/'.join(parts[:i]) for i in range(1, len(parts) + 1)]
         def account_groups(df: pd.DataFrame) -> Dict[str, str]:
             df['nodes'] = [pd.DataFrame({'items': get_nodes_list(path)}) for path in df['group']]
             df = unnest(df, key='nodes')
             return df.groupby('items')['account'].agg('min').to_dict()
-        self._client.update_categories(resource='account', target=account_groups(target), delete=delete)
+        self._client.update_categories(resource='account',
+                                       target=account_groups(target),
+                                       delete=delete,
+                                       ignore_account_root_nodes=True)
 
         for row in to_add.to_dict('records'):
             self.add_account(


### PR DESCRIPTION
This PR covers following changes:
1. Add an option `ignore_account_root_nodes: bool = False` to `CashCtrlClient.update_categories()`. When set, we silently ignore additions, updates and deletions of root account categories. 
2. Modify `mirror_account_chart()` to activate this option. Remove trick on  [ledger.py#L140](https://github.com/macxred/cashctrl_ledger/blob/7cc2d6fab7/cashctrl_ledger/ledger.py#L140) that ignores root node most of the time but fails to work in some circumstance.

[First commit](https://github.com/macxred/cashctrl_ledger/pull/42/commits/6d73bc715a4c3b8e6592411a3d2e43fb241f84f6) - shows the issue exist with the new test suit
[Second commit](https://github.com/macxred/cashctrl_ledger/pull/42/commits/6db2462cfad83ac5a0488bc2b6ba9623d1b1d491) - fixes the issue

@lasuk Please review the changes and provide feedback or approval for merging.