### PR TITLE
Feat/create get journal attachments function

### DIFF
--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -315,7 +315,8 @@ class CashCtrlLedger(LedgerEngine):
         Finds real attachments for the ledger entries and places them in the 'attachments columns'
 
         Returns:
-            pd.DataFrame: A DataFrame with LedgerEngine.ledger() column schema.
+            Dict[str, List[str]]: A Dict that contain pairs of key as ledger Id and value
+            as list of strings of attached files.
         """
         ledger = self._client.list_journal_entries()
         ledger_attached = ledger[ledger['attachmentCount'] > 0]

--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -312,7 +312,7 @@ class CashCtrlLedger(LedgerEngine):
 
     def _get_ledger_attachments(self) -> Dict[str, List[str]]:
         """
-        Finds real attachments for the ledger entries and places them in the 'attachments columns'
+        Locates a path list of real attachments for the ledger entries
 
         Returns:
             Dict[str, List[str]]: A Dict that contain pairs of key as ledger Id and value

--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -383,12 +383,15 @@ class CashCtrlLedger(LedgerEngine):
 
         return StandaloneLedger.standardize_ledger(result)
 
-    def add_ledger_entry(self, entry: pd.DataFrame):
+    def add_ledger_entry(self, entry: pd.DataFrame) -> int:
         """
         Adds a new ledger entry to the remote CashCtrl instance.
 
         Parameters:
             entry (pd.DataFrame): DataFrame with the ledger schema
+
+        Returns:
+            int: The Id of created ledger entry.
         """
         entry = StandaloneLedger.standardize_ledger(entry)
 
@@ -428,8 +431,9 @@ class CashCtrlLedger(LedgerEngine):
         else:
             raise ValueError('The ledger entry contains no transaction.')
 
-        self._client.post("journal/create.json", data=payload)
+        res = self._client.post("journal/create.json", data=payload)
         self._client.invalidate_journal_cache()
+        return res['insertId']
 
     def update_ledger_entry(self, entry: pd.DataFrame):
         """

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -351,7 +351,7 @@ def test_mirror_ledger(add_vat_code):
 def test_get_ledger_attachments(files):
     cashctrl_ledger = CashCtrlLedger()
 
-    # Mirror ledger entries
+    # Populate ledger
     target = pd.concat([individual_transaction, collective_transaction])
     initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
     cashctrl_ledger.mirror_ledger(target=target)
@@ -360,7 +360,7 @@ def test_get_ledger_attachments(files):
     created_ledger = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1)
     document_dict = created_ledger.set_index('id')['document'].to_dict()
 
-    # Manually attach files
+    # Attach files
     for id, document in document_dict.items():
         file_id = cashctrl_ledger._client.file_path_to_id(document)
         cashctrl_ledger._client.post("journal/update_attachments.json", data={'id': id, 'fileIds': file_id})

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -101,6 +101,253 @@ def txn_to_str(df: pd.DataFrame) -> List[str]:
     result = [f'{str(date)},{df_to_consistent_str(txn)}' for date, txn in zip(df['date'], df['txn'])]
     return result.sort()
 
+def test_ledger_accessor_mutators_single_transaction(add_vat_code):
+    cashctrl_ledger = CashCtrlLedger()
+
+    # Test adding a ledger entry
+    initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+    cashctrl_ledger.add_ledger_entry(entry=individual_transaction)
+    updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+    outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
+    created = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
+    expected = StandaloneLedger.standardize_ledger(individual_transaction)
+    pd.testing.assert_frame_equal(created.drop(columns=['id']), expected.drop(columns=['id']))
+
+    # Test delete the created ledger entry
+    cashctrl_ledger.delete_ledger_entry(ids=created['id'].iat[0])
+    ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+    assert created['id'].iat[0] not in ledger['id']
+
+    # Test adding a ledger entry without VAT code
+    initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+    new_entry = individual_transaction.copy()
+    new_entry['vat_code'] = None
+    new_entry['text'] = 'Ledger entry without VAT'
+    cashctrl_ledger.add_ledger_entry(entry=new_entry)
+    updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+    outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
+    created = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
+    expected = StandaloneLedger.standardize_ledger(new_entry)
+    pd.testing.assert_frame_equal(created.drop(columns=['id']), expected.drop(columns=['id']))
+
+    # Test update a ledger entry
+    initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+    new_entry = individual_transaction.copy()
+    new_entry['amount'].iat[0] = 300
+    new_entry['id'] = created['id'].iat[0]
+    cashctrl_ledger.update_ledger_entry(entry=new_entry)
+    updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+    outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
+    updated = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
+    expected = StandaloneLedger.standardize_ledger(new_entry)
+    pd.testing.assert_frame_equal(updated, expected)
+
+    # TODO: CashCtrl doesn`t allow to convert a single transaction into collective
+    # transaction if the single transaction has a taxId assigned. Tracked as cashctrl_ledger#27.
+    # As a workaround, we reset the taxId manually before update with a collective transaction
+    new_entry['vat_code'] = None
+    cashctrl_ledger.update_ledger_entry(entry=new_entry)
+
+    # Test replace with an collective ledger entry
+    initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+    new_entry = collective_transaction.copy()
+    new_entry['id'] = created['id'].iat[0]
+    cashctrl_ledger.update_ledger_entry(entry=new_entry)
+    updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+    outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
+    updated = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
+    expected = StandaloneLedger.standardize_ledger(new_entry)
+    pd.testing.assert_frame_equal(updated, expected)
+
+    # Test delete the updated ledger entry
+    cashctrl_ledger.delete_ledger_entry(ids=created['id'].iat[0])
+    ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+    assert created['id'].iat[0] not in ledger['id']
+
+def test_ledger_accessor_mutators_collective_transaction(add_vat_code):
+    cashctrl_ledger = CashCtrlLedger()
+
+    # Test adding a ledger entry
+    initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+    cashctrl_ledger.add_ledger_entry(entry=collective_transaction)
+    updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+    outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
+    created = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
+    expected = StandaloneLedger.standardize_ledger(collective_transaction)
+    pd.testing.assert_frame_equal(created.drop(columns=['id']), expected.drop(columns=['id']))
+
+    # Test delete the created ledger entry
+    cashctrl_ledger.delete_ledger_entry(ids=created['id'].iat[0])
+    ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+    assert created['id'].iat[0] not in ledger['id']
+
+    # Test adding a ledger entry without VAT
+    initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+    new_entry = collective_transaction.copy()
+    new_entry['vat_code'] = None
+    cashctrl_ledger.add_ledger_entry(entry=new_entry)
+    updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+    outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
+    created = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
+    expected = StandaloneLedger.standardize_ledger(new_entry)
+    pd.testing.assert_frame_equal(created.drop(columns=['id']), expected.drop(columns=['id']))
+
+    # Test update a ledger entry
+    initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+    new_entry = collective_transaction.copy()
+    new_entry['amount'].iat[0] = 300
+    new_entry['amount'].iat[1] = -300
+    new_entry['id'] = created['id'].iat[0]
+    cashctrl_ledger.update_ledger_entry(entry=new_entry)
+    updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+    outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
+    updated = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
+    expected = StandaloneLedger.standardize_ledger(new_entry)
+    pd.testing.assert_frame_equal(updated, expected)
+
+    # Test replace with an individual ledger entry
+    initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+    new_entry = individual_transaction.copy()
+    new_entry['id'] = created['id'].iat[0]
+    new_entry['vat_code'] = None
+    cashctrl_ledger.update_ledger_entry(entry=new_entry)
+    updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+    outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
+    updated = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
+    expected = StandaloneLedger.standardize_ledger(new_entry)
+    pd.testing.assert_frame_equal(updated, expected)
+
+    # Test delete the updated ledger entry
+    cashctrl_ledger.delete_ledger_entry(ids=created['id'].iat[0])
+    ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+    assert created['id'].iat[0] not in ledger['id']
+
+# Tests for addition logic edge cases
+def test_add_ledger_with_non_existent_vat():
+    cashctrl_ledger = CashCtrlLedger()
+
+    # Adding a ledger with non existent VAT code should raise an error
+    entry = individual_transaction.copy()
+    entry['vat_code'].iat[0] = 'Test_Non_Existent_VAT_code'
+    with pytest.raises(ValueError, match='No id found for tax code'):
+        cashctrl_ledger.add_ledger_entry(entry=entry)
+
+    # Adding a ledger with non existent account code should raise an error
+    entry = individual_transaction.copy()
+    entry['account'].iat[0] = 33333
+    with pytest.raises(ValueError, match='No id found for account'):
+        cashctrl_ledger.add_ledger_entry(entry=entry)
+
+    # Adding a ledger with non existent currency code should raise an error
+    entry = individual_transaction.copy()
+    entry['currency'].iat[0] = 'Non_Existent_Currency'
+    with pytest.raises(ValueError, match='No id found for currency'):
+        cashctrl_ledger.add_ledger_entry(entry=entry)
+
+# Tests for updating logic edge cases
+def test_update_ledger_with_edge_cases(add_vat_code):
+    cashctrl_ledger = CashCtrlLedger()
+
+    initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+    cashctrl_ledger.add_ledger_entry(entry=individual_transaction)
+    updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+    outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
+    created = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
+
+    # Updating a ledger with non existent VAT code should raise an error
+    new_entry = individual_transaction.copy()
+    new_entry['id'] = created['id'].iat[0]
+    new_entry['vat_code'].iat[0] = 'Test_Non_Existent_VAT_code'
+    with pytest.raises(ValueError, match='No id found for tax code'):
+        cashctrl_ledger.update_ledger_entry(entry=new_entry)
+
+    # Updating a ledger with non existent account code should raise an error
+    new_entry = individual_transaction.copy()
+    new_entry['id'] = created['id'].iat[0]
+    new_entry['account'].iat[0] = 333333
+    with pytest.raises(ValueError, match='No id found for account'):
+        cashctrl_ledger.update_ledger_entry(entry=new_entry)
+
+    # Updating a ledger with non existent currency code should raise an error
+    new_entry = individual_transaction.copy()
+    new_entry['id'] = created['id'].iat[0]
+    new_entry['currency'].iat[0] = 'CURRENCY'
+    with pytest.raises(ValueError, match='No id found for currency'):
+        cashctrl_ledger.update_ledger_entry(entry=new_entry)
+
+    # Delete the ledger entry created above
+    cashctrl_ledger.delete_ledger_entry(ids=created['id'].iat[0])
+    ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+    assert created['id'].iat[0] not in ledger['id']
+
+# Updating a non-existent ledger should raise an error
+def test_update_non_existent_ledger():
+    cashctrl_ledger = CashCtrlLedger()
+    entry = individual_transaction.copy()
+    entry['id'].iat[0] = 999999
+    with pytest.raises(RequestException):
+        cashctrl_ledger.update_ledger_entry(entry=entry)
+
+# Deleting a non-existent ledger should raise an error
+def test_delete_non_existent_ledger():
+    cashctrl_ledger = CashCtrlLedger()
+    with pytest.raises(RequestException):
+        cashctrl_ledger.delete_ledger_entry(ids='non-existent')
+
+def test_mirror_ledger(add_vat_code):
+    cashctrl_ledger = CashCtrlLedger()
+    initial = cashctrl_ledger.ledger().reset_index(drop=True)
+
+    # Mirror with one single and one collective transaction
+    target = pd.concat([individual_transaction, collective_transaction])
+    cashctrl_ledger.mirror_ledger(target=target)
+    mirrored = cashctrl_ledger.ledger()
+    assert txn_to_str(target) == txn_to_str(mirrored)
+
+    # Mirror with duplicate transactions and delete=False
+    new_individual_transaction = individual_transaction.copy()
+    new_collective_transaction = collective_transaction.copy()
+    new_individual_transaction['id'].iat[0] = 5
+    new_collective_transaction['id'].iat[0] = 6
+    new_collective_transaction['id'].iat[1] = 6
+    target = pd.concat([
+        individual_transaction,
+        new_individual_transaction,
+        collective_transaction,
+        new_collective_transaction,
+    ])
+    cashctrl_ledger.mirror_ledger(target=target)
+    mirrored = cashctrl_ledger.ledger().reset_index(drop=True)
+    assert txn_to_str(target) == txn_to_str(mirrored)
+
+    # Mirror with alternative transactions and delete=False
+    target = pd.concat([alt_individual_transaction, alt_collective_transaction])
+    expected = pd.concat([mirrored, target])
+    cashctrl_ledger.mirror_ledger(target=target, delete=False)
+    mirrored = cashctrl_ledger.ledger().reset_index(drop=True)
+    assert txn_to_str(mirrored) == txn_to_str(expected)
+
+    # Mirror with delete=False
+    target = pd.concat([individual_transaction, collective_transaction])
+    cashctrl_ledger.mirror_ledger(target=target, delete=False)
+    mirrored = cashctrl_ledger.ledger().reset_index(drop=True)
+    assert txn_to_str(target) == txn_to_str(mirrored)
+
+    # Mirror with delete=True
+    target = pd.concat([individual_transaction, collective_transaction])
+    cashctrl_ledger.mirror_ledger(target=target)
+    mirrored = cashctrl_ledger.ledger().reset_index(drop=True)
+    assert txn_to_str(target) == txn_to_str(mirrored)
+
+    # Mirror an empty target state
+    cashctrl_ledger.mirror_ledger(target=pd.DataFrame({}), delete=True)
+    assert cashctrl_ledger.ledger().empty
+
+    # Restore initial state
+    cashctrl_ledger.mirror_ledger(target=initial, delete=True)
+    mirrored = cashctrl_ledger.ledger().reset_index(drop=True)
+    assert txn_to_str(initial) == txn_to_str(mirrored)
+
 def test_get_ledger_attachments(files):
     cashctrl_ledger = CashCtrlLedger()
 
@@ -117,258 +364,17 @@ def test_get_ledger_attachments(files):
     for id, document in document_dict.items():
         file_id = cashctrl_ledger._client.file_path_to_id(document)
         cashctrl_ledger._client.post("journal/update_attachments.json", data={'id': id, 'fileIds': file_id})
+    cashctrl_ledger._client.invalidate_journal_cache()
 
-    breakpoint()
-    # check is attachments column values matches expectation
     attachments = cashctrl_ledger._get_ledger_attachments()
+    attachments = {str(key): ','.join(value) for key, value in attachments.items()}
+    updated_ledger = cashctrl_ledger.ledger()
+    ledger_attachments = updated_ledger.set_index('id')['document'].to_dict()
+    assert ledger_attachments == attachments, (
+        'Files were not attached or attached incorrectly'
+    )
 
-    breakpoint()
+    # Restore initial state
     cashctrl_ledger.mirror_ledger(target=initial_ledger, delete=True)
-
-
-# def test_ledger_accessor_mutators_single_transaction(add_vat_code):
-#     cashctrl_ledger = CashCtrlLedger()
-
-#     # Test adding a ledger entry
-#     initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-#     cashctrl_ledger.add_ledger_entry(entry=individual_transaction)
-#     updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-#     outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
-#     created = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
-#     expected = StandaloneLedger.standardize_ledger(individual_transaction)
-#     pd.testing.assert_frame_equal(created.drop(columns=['id']), expected.drop(columns=['id']))
-
-#     # Test delete the created ledger entry
-#     cashctrl_ledger.delete_ledger_entry(ids=created['id'].iat[0])
-#     ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-#     assert created['id'].iat[0] not in ledger['id']
-
-#     # Test adding a ledger entry without VAT code
-#     initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-#     new_entry = individual_transaction.copy()
-#     new_entry['vat_code'] = None
-#     new_entry['text'] = 'Ledger entry without VAT'
-#     cashctrl_ledger.add_ledger_entry(entry=new_entry)
-#     updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-#     outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
-#     created = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
-#     expected = StandaloneLedger.standardize_ledger(new_entry)
-#     pd.testing.assert_frame_equal(created.drop(columns=['id']), expected.drop(columns=['id']))
-
-#     # Test update a ledger entry
-#     initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-#     new_entry = individual_transaction.copy()
-#     new_entry['amount'].iat[0] = 300
-#     new_entry['id'] = created['id'].iat[0]
-#     cashctrl_ledger.update_ledger_entry(entry=new_entry)
-#     updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-#     outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
-#     updated = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
-#     expected = StandaloneLedger.standardize_ledger(new_entry)
-#     pd.testing.assert_frame_equal(updated, expected)
-
-#     # TODO: CashCtrl doesn`t allow to convert a single transaction into collective
-#     # transaction if the single transaction has a taxId assigned. Tracked as cashctrl_ledger#27.
-#     # As a workaround, we reset the taxId manually before update with a collective transaction
-#     new_entry['vat_code'] = None
-#     cashctrl_ledger.update_ledger_entry(entry=new_entry)
-
-#     # Test replace with an collective ledger entry
-#     initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-#     new_entry = collective_transaction.copy()
-#     new_entry['id'] = created['id'].iat[0]
-#     cashctrl_ledger.update_ledger_entry(entry=new_entry)
-#     updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-#     outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
-#     updated = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
-#     expected = StandaloneLedger.standardize_ledger(new_entry)
-#     pd.testing.assert_frame_equal(updated, expected)
-
-#     # Test delete the updated ledger entry
-#     cashctrl_ledger.delete_ledger_entry(ids=created['id'].iat[0])
-#     ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-#     assert created['id'].iat[0] not in ledger['id']
-
-# def test_ledger_accessor_mutators_collective_transaction(add_vat_code):
-#     cashctrl_ledger = CashCtrlLedger()
-
-#     # Test adding a ledger entry
-#     initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-#     cashctrl_ledger.add_ledger_entry(entry=collective_transaction)
-#     updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-#     outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
-#     created = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
-#     expected = StandaloneLedger.standardize_ledger(collective_transaction)
-#     pd.testing.assert_frame_equal(created.drop(columns=['id']), expected.drop(columns=['id']))
-
-#     # Test delete the created ledger entry
-#     cashctrl_ledger.delete_ledger_entry(ids=created['id'].iat[0])
-#     ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-#     assert created['id'].iat[0] not in ledger['id']
-
-#     # Test adding a ledger entry without VAT
-#     initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-#     new_entry = collective_transaction.copy()
-#     new_entry['vat_code'] = None
-#     cashctrl_ledger.add_ledger_entry(entry=new_entry)
-#     updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-#     outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
-#     created = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
-#     expected = StandaloneLedger.standardize_ledger(new_entry)
-#     pd.testing.assert_frame_equal(created.drop(columns=['id']), expected.drop(columns=['id']))
-
-#     # Test update a ledger entry
-#     initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-#     new_entry = collective_transaction.copy()
-#     new_entry['amount'].iat[0] = 300
-#     new_entry['amount'].iat[1] = -300
-#     new_entry['id'] = created['id'].iat[0]
-#     cashctrl_ledger.update_ledger_entry(entry=new_entry)
-#     updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-#     outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
-#     updated = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
-#     expected = StandaloneLedger.standardize_ledger(new_entry)
-#     pd.testing.assert_frame_equal(updated, expected)
-
-#     # Test replace with an individual ledger entry
-#     initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-#     new_entry = individual_transaction.copy()
-#     new_entry['id'] = created['id'].iat[0]
-#     new_entry['vat_code'] = None
-#     cashctrl_ledger.update_ledger_entry(entry=new_entry)
-#     updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-#     outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
-#     updated = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
-#     expected = StandaloneLedger.standardize_ledger(new_entry)
-#     pd.testing.assert_frame_equal(updated, expected)
-
-#     # Test delete the updated ledger entry
-#     cashctrl_ledger.delete_ledger_entry(ids=created['id'].iat[0])
-#     ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-#     assert created['id'].iat[0] not in ledger['id']
-
-# # Tests for addition logic edge cases
-# def test_add_ledger_with_non_existent_vat():
-#     cashctrl_ledger = CashCtrlLedger()
-
-#     # Adding a ledger with non existent VAT code should raise an error
-#     entry = individual_transaction.copy()
-#     entry['vat_code'].iat[0] = 'Test_Non_Existent_VAT_code'
-#     with pytest.raises(ValueError, match='No id found for tax code'):
-#         cashctrl_ledger.add_ledger_entry(entry=entry)
-
-#     # Adding a ledger with non existent account code should raise an error
-#     entry = individual_transaction.copy()
-#     entry['account'].iat[0] = 33333
-#     with pytest.raises(ValueError, match='No id found for account'):
-#         cashctrl_ledger.add_ledger_entry(entry=entry)
-
-#     # Adding a ledger with non existent currency code should raise an error
-#     entry = individual_transaction.copy()
-#     entry['currency'].iat[0] = 'Non_Existent_Currency'
-#     with pytest.raises(ValueError, match='No id found for currency'):
-#         cashctrl_ledger.add_ledger_entry(entry=entry)
-
-# # Tests for updating logic edge cases
-# def test_update_ledger_with_edge_cases(add_vat_code):
-#     cashctrl_ledger = CashCtrlLedger()
-
-#     initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-#     cashctrl_ledger.add_ledger_entry(entry=individual_transaction)
-#     updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-#     outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
-#     created = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
-
-#     # Updating a ledger with non existent VAT code should raise an error
-#     new_entry = individual_transaction.copy()
-#     new_entry['id'] = created['id'].iat[0]
-#     new_entry['vat_code'].iat[0] = 'Test_Non_Existent_VAT_code'
-#     with pytest.raises(ValueError, match='No id found for tax code'):
-#         cashctrl_ledger.update_ledger_entry(entry=new_entry)
-
-#     # Updating a ledger with non existent account code should raise an error
-#     new_entry = individual_transaction.copy()
-#     new_entry['id'] = created['id'].iat[0]
-#     new_entry['account'].iat[0] = 333333
-#     with pytest.raises(ValueError, match='No id found for account'):
-#         cashctrl_ledger.update_ledger_entry(entry=new_entry)
-
-#     # Updating a ledger with non existent currency code should raise an error
-#     new_entry = individual_transaction.copy()
-#     new_entry['id'] = created['id'].iat[0]
-#     new_entry['currency'].iat[0] = 'CURRENCY'
-#     with pytest.raises(ValueError, match='No id found for currency'):
-#         cashctrl_ledger.update_ledger_entry(entry=new_entry)
-
-#     # Delete the ledger entry created above
-#     cashctrl_ledger.delete_ledger_entry(ids=created['id'].iat[0])
-#     ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-#     assert created['id'].iat[0] not in ledger['id']
-
-# # Updating a non-existent ledger should raise an error
-# def test_update_non_existent_ledger():
-#     cashctrl_ledger = CashCtrlLedger()
-#     entry = individual_transaction.copy()
-#     entry['id'].iat[0] = 999999
-#     with pytest.raises(RequestException):
-#         cashctrl_ledger.update_ledger_entry(entry=entry)
-
-# # Deleting a non-existent ledger should raise an error
-# def test_delete_non_existent_ledger():
-#     cashctrl_ledger = CashCtrlLedger()
-#     with pytest.raises(RequestException):
-#         cashctrl_ledger.delete_ledger_entry(ids='non-existent')
-
-# def test_mirror_ledger(add_vat_code):
-#     cashctrl_ledger = CashCtrlLedger()
-#     initial = cashctrl_ledger.ledger().reset_index(drop=True)
-
-#     # Mirror with one single and one collective transaction
-#     target = pd.concat([individual_transaction, collective_transaction])
-#     cashctrl_ledger.mirror_ledger(target=target)
-#     mirrored = cashctrl_ledger.ledger()
-#     assert txn_to_str(target) == txn_to_str(mirrored)
-
-#     # Mirror with duplicate transactions and delete=False
-#     new_individual_transaction = individual_transaction.copy()
-#     new_collective_transaction = collective_transaction.copy()
-#     new_individual_transaction['id'].iat[0] = 5
-#     new_collective_transaction['id'].iat[0] = 6
-#     new_collective_transaction['id'].iat[1] = 6
-#     target = pd.concat([
-#         individual_transaction,
-#         new_individual_transaction,
-#         collective_transaction,
-#         new_collective_transaction,
-#     ])
-#     cashctrl_ledger.mirror_ledger(target=target)
-#     mirrored = cashctrl_ledger.ledger().reset_index(drop=True)
-#     assert txn_to_str(target) == txn_to_str(mirrored)
-
-#     # Mirror with alternative transactions and delete=False
-#     target = pd.concat([alt_individual_transaction, alt_collective_transaction])
-#     expected = pd.concat([mirrored, target])
-#     cashctrl_ledger.mirror_ledger(target=target, delete=False)
-#     mirrored = cashctrl_ledger.ledger().reset_index(drop=True)
-#     assert txn_to_str(mirrored) == txn_to_str(expected)
-
-#     # Mirror with delete=False
-#     target = pd.concat([individual_transaction, collective_transaction])
-#     cashctrl_ledger.mirror_ledger(target=target, delete=False)
-#     mirrored = cashctrl_ledger.ledger().reset_index(drop=True)
-#     assert txn_to_str(target) == txn_to_str(mirrored)
-
-#     # Mirror with delete=True
-#     target = pd.concat([individual_transaction, collective_transaction])
-#     cashctrl_ledger.mirror_ledger(target=target)
-#     mirrored = cashctrl_ledger.ledger().reset_index(drop=True)
-#     assert txn_to_str(target) == txn_to_str(mirrored)
-
-#     # Mirror an empty target state
-#     cashctrl_ledger.mirror_ledger(target=pd.DataFrame({}), delete=True)
-#     assert cashctrl_ledger.ledger().empty
-
-#     # Restore initial state
-#     cashctrl_ledger.mirror_ledger(target=initial, delete=True)
-#     mirrored = cashctrl_ledger.ledger().reset_index(drop=True)
-#     assert txn_to_str(initial) == txn_to_str(mirrored)
+    restored_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+    pd.testing.assert_frame_equal(initial_ledger, restored_ledger)

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -368,6 +368,8 @@ def test_mirror_ledger(add_vat_code):
     assert txn_to_str(initial) == txn_to_str(mirrored)
 
 def test_get_ledger_attachments(files, ledger_ids):
+    def sort_dict_values(items):
+        return {key: value.sort() for key, value in items.items()}
     engine = CashCtrlLedger()
     initial = engine._get_ledger_attachments()
 
@@ -385,7 +387,4 @@ def test_get_ledger_attachments(files, ledger_ids):
     engine._client.post("journal/update_attachments.json", data={'id': ledger_ids[1], 'fileIds': file_ids})
     engine._client.invalidate_journal_cache()
     expected = initial | {ledger_ids[0]: ['/file1.txt'], ledger_ids[1]:  ['/file1.txt', '/subdir/file2.txt']}
-    expected[ledger_ids[1]].sort()
-    attachments = engine._get_ledger_attachments()
-    attachments[ledger_ids[1]].sort()
-    assert attachments == expected
+    assert sort_dict_values(engine._get_ledger_attachments()) == sort_dict_values(expected)

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -71,249 +71,264 @@ def txn_to_str(df: pd.DataFrame) -> List[str]:
     result = [f'{str(date)},{df_to_consistent_str(txn)}' for date, txn in zip(df['date'], df['txn'])]
     return result.sort()
 
-def test_ledger_accessor_mutators_single_transaction(add_vat_code):
+def test_get_ledger_attachments():
     cashctrl_ledger = CashCtrlLedger()
+    # create two files in root directory and return fileId from fixture
+    # create in root and in some subdirectory
 
-    # Test adding a ledger entry
-    initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    cashctrl_ledger.add_ledger_entry(entry=individual_transaction)
-    updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
-    created = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
-    expected = StandaloneLedger.standardize_ledger(individual_transaction)
-    pd.testing.assert_frame_equal(created.drop(columns=['id']), expected.drop(columns=['id']))
+    # mirror one single and one collective entry
 
-    # Test delete the created ledger entry
-    cashctrl_ledger.delete_ledger_entry(ids=created['id'].iat[0])
-    ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    assert created['id'].iat[0] not in ledger['id']
+    # manually attach files
+    # cashctrl_ledger._client.post("journal/update_attachments.json", data={'id': 'ledger_id', 'fileIds': 'file_created_id'})
 
-    # Test adding a ledger entry without VAT code
-    initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    new_entry = individual_transaction.copy()
-    new_entry['vat_code'] = None
-    new_entry['text'] = 'Ledger entry without VAT'
-    cashctrl_ledger.add_ledger_entry(entry=new_entry)
-    updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
-    created = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
-    expected = StandaloneLedger.standardize_ledger(new_entry)
-    pd.testing.assert_frame_equal(created.drop(columns=['id']), expected.drop(columns=['id']))
+    # check is attachments column values matches expectation
+    dict = cashctrl_ledger._get_ledger_attachments()
 
-    # Test update a ledger entry
-    initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    new_entry = individual_transaction.copy()
-    new_entry['amount'].iat[0] = 300
-    new_entry['id'] = created['id'].iat[0]
-    cashctrl_ledger.update_ledger_entry(entry=new_entry)
-    updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
-    updated = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
-    expected = StandaloneLedger.standardize_ledger(new_entry)
-    pd.testing.assert_frame_equal(updated, expected)
+    breakpoint()
 
-    # TODO: CashCtrl doesn`t allow to convert a single transaction into collective
-    # transaction if the single transaction has a taxId assigned. Tracked as cashctrl_ledger#27.
-    # As a workaround, we reset the taxId manually before update with a collective transaction
-    new_entry['vat_code'] = None
-    cashctrl_ledger.update_ledger_entry(entry=new_entry)
+# def test_ledger_accessor_mutators_single_transaction(add_vat_code):
+#     cashctrl_ledger = CashCtrlLedger()
 
-    # Test replace with an collective ledger entry
-    initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    new_entry = collective_transaction.copy()
-    new_entry['id'] = created['id'].iat[0]
-    cashctrl_ledger.update_ledger_entry(entry=new_entry)
-    updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
-    updated = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
-    expected = StandaloneLedger.standardize_ledger(new_entry)
-    pd.testing.assert_frame_equal(updated, expected)
+#     # Test adding a ledger entry
+#     initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+#     cashctrl_ledger.add_ledger_entry(entry=individual_transaction)
+#     updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+#     outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
+#     created = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
+#     expected = StandaloneLedger.standardize_ledger(individual_transaction)
+#     pd.testing.assert_frame_equal(created.drop(columns=['id']), expected.drop(columns=['id']))
 
-    # Test delete the updated ledger entry
-    cashctrl_ledger.delete_ledger_entry(ids=created['id'].iat[0])
-    ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    assert created['id'].iat[0] not in ledger['id']
+#     # Test delete the created ledger entry
+#     cashctrl_ledger.delete_ledger_entry(ids=created['id'].iat[0])
+#     ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+#     assert created['id'].iat[0] not in ledger['id']
 
-def test_ledger_accessor_mutators_collective_transaction(add_vat_code):
-    cashctrl_ledger = CashCtrlLedger()
+#     # Test adding a ledger entry without VAT code
+#     initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+#     new_entry = individual_transaction.copy()
+#     new_entry['vat_code'] = None
+#     new_entry['text'] = 'Ledger entry without VAT'
+#     cashctrl_ledger.add_ledger_entry(entry=new_entry)
+#     updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+#     outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
+#     created = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
+#     expected = StandaloneLedger.standardize_ledger(new_entry)
+#     pd.testing.assert_frame_equal(created.drop(columns=['id']), expected.drop(columns=['id']))
 
-    # Test adding a ledger entry
-    initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    cashctrl_ledger.add_ledger_entry(entry=collective_transaction)
-    updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
-    created = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
-    expected = StandaloneLedger.standardize_ledger(collective_transaction)
-    pd.testing.assert_frame_equal(created.drop(columns=['id']), expected.drop(columns=['id']))
+#     # Test update a ledger entry
+#     initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+#     new_entry = individual_transaction.copy()
+#     new_entry['amount'].iat[0] = 300
+#     new_entry['id'] = created['id'].iat[0]
+#     cashctrl_ledger.update_ledger_entry(entry=new_entry)
+#     updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+#     outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
+#     updated = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
+#     expected = StandaloneLedger.standardize_ledger(new_entry)
+#     pd.testing.assert_frame_equal(updated, expected)
 
-    # Test delete the created ledger entry
-    cashctrl_ledger.delete_ledger_entry(ids=created['id'].iat[0])
-    ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    assert created['id'].iat[0] not in ledger['id']
+#     # TODO: CashCtrl doesn`t allow to convert a single transaction into collective
+#     # transaction if the single transaction has a taxId assigned. Tracked as cashctrl_ledger#27.
+#     # As a workaround, we reset the taxId manually before update with a collective transaction
+#     new_entry['vat_code'] = None
+#     cashctrl_ledger.update_ledger_entry(entry=new_entry)
 
-    # Test adding a ledger entry without VAT
-    initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    new_entry = collective_transaction.copy()
-    new_entry['vat_code'] = None
-    cashctrl_ledger.add_ledger_entry(entry=new_entry)
-    updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
-    created = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
-    expected = StandaloneLedger.standardize_ledger(new_entry)
-    pd.testing.assert_frame_equal(created.drop(columns=['id']), expected.drop(columns=['id']))
+#     # Test replace with an collective ledger entry
+#     initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+#     new_entry = collective_transaction.copy()
+#     new_entry['id'] = created['id'].iat[0]
+#     cashctrl_ledger.update_ledger_entry(entry=new_entry)
+#     updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+#     outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
+#     updated = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
+#     expected = StandaloneLedger.standardize_ledger(new_entry)
+#     pd.testing.assert_frame_equal(updated, expected)
 
-    # Test update a ledger entry
-    initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    new_entry = collective_transaction.copy()
-    new_entry['amount'].iat[0] = 300
-    new_entry['amount'].iat[1] = -300
-    new_entry['id'] = created['id'].iat[0]
-    cashctrl_ledger.update_ledger_entry(entry=new_entry)
-    updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
-    updated = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
-    expected = StandaloneLedger.standardize_ledger(new_entry)
-    pd.testing.assert_frame_equal(updated, expected)
+#     # Test delete the updated ledger entry
+#     cashctrl_ledger.delete_ledger_entry(ids=created['id'].iat[0])
+#     ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+#     assert created['id'].iat[0] not in ledger['id']
 
-    # Test replace with an individual ledger entry
-    initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    new_entry = individual_transaction.copy()
-    new_entry['id'] = created['id'].iat[0]
-    new_entry['vat_code'] = None
-    cashctrl_ledger.update_ledger_entry(entry=new_entry)
-    updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
-    updated = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
-    expected = StandaloneLedger.standardize_ledger(new_entry)
-    pd.testing.assert_frame_equal(updated, expected)
+# def test_ledger_accessor_mutators_collective_transaction(add_vat_code):
+#     cashctrl_ledger = CashCtrlLedger()
 
-    # Test delete the updated ledger entry
-    cashctrl_ledger.delete_ledger_entry(ids=created['id'].iat[0])
-    ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    assert created['id'].iat[0] not in ledger['id']
+#     # Test adding a ledger entry
+#     initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+#     cashctrl_ledger.add_ledger_entry(entry=collective_transaction)
+#     updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+#     outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
+#     created = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
+#     expected = StandaloneLedger.standardize_ledger(collective_transaction)
+#     pd.testing.assert_frame_equal(created.drop(columns=['id']), expected.drop(columns=['id']))
 
-# Tests for addition logic edge cases
-def test_add_ledger_with_non_existent_vat():
-    cashctrl_ledger = CashCtrlLedger()
+#     # Test delete the created ledger entry
+#     cashctrl_ledger.delete_ledger_entry(ids=created['id'].iat[0])
+#     ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+#     assert created['id'].iat[0] not in ledger['id']
 
-    # Adding a ledger with non existent VAT code should raise an error
-    entry = individual_transaction.copy()
-    entry['vat_code'].iat[0] = 'Test_Non_Existent_VAT_code'
-    with pytest.raises(ValueError, match='No id found for tax code'):
-        cashctrl_ledger.add_ledger_entry(entry=entry)
+#     # Test adding a ledger entry without VAT
+#     initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+#     new_entry = collective_transaction.copy()
+#     new_entry['vat_code'] = None
+#     cashctrl_ledger.add_ledger_entry(entry=new_entry)
+#     updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+#     outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
+#     created = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
+#     expected = StandaloneLedger.standardize_ledger(new_entry)
+#     pd.testing.assert_frame_equal(created.drop(columns=['id']), expected.drop(columns=['id']))
 
-    # Adding a ledger with non existent account code should raise an error
-    entry = individual_transaction.copy()
-    entry['account'].iat[0] = 33333
-    with pytest.raises(ValueError, match='No id found for account'):
-        cashctrl_ledger.add_ledger_entry(entry=entry)
+#     # Test update a ledger entry
+#     initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+#     new_entry = collective_transaction.copy()
+#     new_entry['amount'].iat[0] = 300
+#     new_entry['amount'].iat[1] = -300
+#     new_entry['id'] = created['id'].iat[0]
+#     cashctrl_ledger.update_ledger_entry(entry=new_entry)
+#     updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+#     outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
+#     updated = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
+#     expected = StandaloneLedger.standardize_ledger(new_entry)
+#     pd.testing.assert_frame_equal(updated, expected)
 
-    # Adding a ledger with non existent currency code should raise an error
-    entry = individual_transaction.copy()
-    entry['currency'].iat[0] = 'Non_Existent_Currency'
-    with pytest.raises(ValueError, match='No id found for currency'):
-        cashctrl_ledger.add_ledger_entry(entry=entry)
+#     # Test replace with an individual ledger entry
+#     initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+#     new_entry = individual_transaction.copy()
+#     new_entry['id'] = created['id'].iat[0]
+#     new_entry['vat_code'] = None
+#     cashctrl_ledger.update_ledger_entry(entry=new_entry)
+#     updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+#     outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
+#     updated = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
+#     expected = StandaloneLedger.standardize_ledger(new_entry)
+#     pd.testing.assert_frame_equal(updated, expected)
 
-# Tests for updating logic edge cases
-def test_update_ledger_with_edge_cases(add_vat_code):
-    cashctrl_ledger = CashCtrlLedger()
+#     # Test delete the updated ledger entry
+#     cashctrl_ledger.delete_ledger_entry(ids=created['id'].iat[0])
+#     ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+#     assert created['id'].iat[0] not in ledger['id']
 
-    initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    cashctrl_ledger.add_ledger_entry(entry=individual_transaction)
-    updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
-    created = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
+# # Tests for addition logic edge cases
+# def test_add_ledger_with_non_existent_vat():
+#     cashctrl_ledger = CashCtrlLedger()
 
-    # Updating a ledger with non existent VAT code should raise an error
-    new_entry = individual_transaction.copy()
-    new_entry['id'] = created['id'].iat[0]
-    new_entry['vat_code'].iat[0] = 'Test_Non_Existent_VAT_code'
-    with pytest.raises(ValueError, match='No id found for tax code'):
-        cashctrl_ledger.update_ledger_entry(entry=new_entry)
+#     # Adding a ledger with non existent VAT code should raise an error
+#     entry = individual_transaction.copy()
+#     entry['vat_code'].iat[0] = 'Test_Non_Existent_VAT_code'
+#     with pytest.raises(ValueError, match='No id found for tax code'):
+#         cashctrl_ledger.add_ledger_entry(entry=entry)
 
-    # Updating a ledger with non existent account code should raise an error
-    new_entry = individual_transaction.copy()
-    new_entry['id'] = created['id'].iat[0]
-    new_entry['account'].iat[0] = 333333
-    with pytest.raises(ValueError, match='No id found for account'):
-        cashctrl_ledger.update_ledger_entry(entry=new_entry)
+#     # Adding a ledger with non existent account code should raise an error
+#     entry = individual_transaction.copy()
+#     entry['account'].iat[0] = 33333
+#     with pytest.raises(ValueError, match='No id found for account'):
+#         cashctrl_ledger.add_ledger_entry(entry=entry)
 
-    # Updating a ledger with non existent currency code should raise an error
-    new_entry = individual_transaction.copy()
-    new_entry['id'] = created['id'].iat[0]
-    new_entry['currency'].iat[0] = 'CURRENCY'
-    with pytest.raises(ValueError, match='No id found for currency'):
-        cashctrl_ledger.update_ledger_entry(entry=new_entry)
+#     # Adding a ledger with non existent currency code should raise an error
+#     entry = individual_transaction.copy()
+#     entry['currency'].iat[0] = 'Non_Existent_Currency'
+#     with pytest.raises(ValueError, match='No id found for currency'):
+#         cashctrl_ledger.add_ledger_entry(entry=entry)
 
-    # Delete the ledger entry created above
-    cashctrl_ledger.delete_ledger_entry(ids=created['id'].iat[0])
-    ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    assert created['id'].iat[0] not in ledger['id']
+# # Tests for updating logic edge cases
+# def test_update_ledger_with_edge_cases(add_vat_code):
+#     cashctrl_ledger = CashCtrlLedger()
 
-# Updating a non-existent ledger should raise an error
-def test_update_non_existent_ledger():
-    cashctrl_ledger = CashCtrlLedger()
-    entry = individual_transaction.copy()
-    entry['id'].iat[0] = 999999
-    with pytest.raises(RequestException):
-        cashctrl_ledger.update_ledger_entry(entry=entry)
+#     initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+#     cashctrl_ledger.add_ledger_entry(entry=individual_transaction)
+#     updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+#     outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
+#     created = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
 
-# Deleting a non-existent ledger should raise an error
-def test_delete_non_existent_ledger():
-    cashctrl_ledger = CashCtrlLedger()
-    with pytest.raises(RequestException):
-        cashctrl_ledger.delete_ledger_entry(ids='non-existent')
+#     # Updating a ledger with non existent VAT code should raise an error
+#     new_entry = individual_transaction.copy()
+#     new_entry['id'] = created['id'].iat[0]
+#     new_entry['vat_code'].iat[0] = 'Test_Non_Existent_VAT_code'
+#     with pytest.raises(ValueError, match='No id found for tax code'):
+#         cashctrl_ledger.update_ledger_entry(entry=new_entry)
 
-def test_mirror_ledger(add_vat_code):
-    cashctrl_ledger = CashCtrlLedger()
-    initial = cashctrl_ledger.ledger().reset_index(drop=True)
+#     # Updating a ledger with non existent account code should raise an error
+#     new_entry = individual_transaction.copy()
+#     new_entry['id'] = created['id'].iat[0]
+#     new_entry['account'].iat[0] = 333333
+#     with pytest.raises(ValueError, match='No id found for account'):
+#         cashctrl_ledger.update_ledger_entry(entry=new_entry)
 
-    # Mirror with one single and one collective transaction
-    target = pd.concat([individual_transaction, collective_transaction])
-    cashctrl_ledger.mirror_ledger(target=target)
-    mirrored = cashctrl_ledger.ledger()
-    assert txn_to_str(target) == txn_to_str(mirrored)
+#     # Updating a ledger with non existent currency code should raise an error
+#     new_entry = individual_transaction.copy()
+#     new_entry['id'] = created['id'].iat[0]
+#     new_entry['currency'].iat[0] = 'CURRENCY'
+#     with pytest.raises(ValueError, match='No id found for currency'):
+#         cashctrl_ledger.update_ledger_entry(entry=new_entry)
 
-    # Mirror with duplicate transactions and delete=False
-    new_individual_transaction = individual_transaction.copy()
-    new_collective_transaction = collective_transaction.copy()
-    new_individual_transaction['id'].iat[0] = 5
-    new_collective_transaction['id'].iat[0] = 6
-    new_collective_transaction['id'].iat[1] = 6
-    target = pd.concat([
-        individual_transaction,
-        new_individual_transaction,
-        collective_transaction,
-        new_collective_transaction,
-    ])
-    cashctrl_ledger.mirror_ledger(target=target)
-    mirrored = cashctrl_ledger.ledger().reset_index(drop=True)
-    assert txn_to_str(target) == txn_to_str(mirrored)
+#     # Delete the ledger entry created above
+#     cashctrl_ledger.delete_ledger_entry(ids=created['id'].iat[0])
+#     ledger = cashctrl_ledger.ledger().reset_index(drop=True)
+#     assert created['id'].iat[0] not in ledger['id']
 
-    # Mirror with alternative transactions and delete=False
-    target = pd.concat([alt_individual_transaction, alt_collective_transaction])
-    expected = pd.concat([mirrored, target])
-    cashctrl_ledger.mirror_ledger(target=target, delete=False)
-    mirrored = cashctrl_ledger.ledger().reset_index(drop=True)
-    assert txn_to_str(mirrored) == txn_to_str(expected)
+# # Updating a non-existent ledger should raise an error
+# def test_update_non_existent_ledger():
+#     cashctrl_ledger = CashCtrlLedger()
+#     entry = individual_transaction.copy()
+#     entry['id'].iat[0] = 999999
+#     with pytest.raises(RequestException):
+#         cashctrl_ledger.update_ledger_entry(entry=entry)
 
-    # Mirror with delete=False
-    target = pd.concat([individual_transaction, collective_transaction])
-    cashctrl_ledger.mirror_ledger(target=target, delete=False)
-    mirrored = cashctrl_ledger.ledger().reset_index(drop=True)
-    assert txn_to_str(target) == txn_to_str(mirrored)
+# # Deleting a non-existent ledger should raise an error
+# def test_delete_non_existent_ledger():
+#     cashctrl_ledger = CashCtrlLedger()
+#     with pytest.raises(RequestException):
+#         cashctrl_ledger.delete_ledger_entry(ids='non-existent')
 
-    # Mirror with delete=True
-    target = pd.concat([individual_transaction, collective_transaction])
-    cashctrl_ledger.mirror_ledger(target=target)
-    mirrored = cashctrl_ledger.ledger().reset_index(drop=True)
-    assert txn_to_str(target) == txn_to_str(mirrored)
+# def test_mirror_ledger(add_vat_code):
+#     cashctrl_ledger = CashCtrlLedger()
+#     initial = cashctrl_ledger.ledger().reset_index(drop=True)
 
-    # Mirror an empty target state
-    cashctrl_ledger.mirror_ledger(target=pd.DataFrame({}), delete=True)
-    assert cashctrl_ledger.ledger().empty
+#     # Mirror with one single and one collective transaction
+#     target = pd.concat([individual_transaction, collective_transaction])
+#     cashctrl_ledger.mirror_ledger(target=target)
+#     mirrored = cashctrl_ledger.ledger()
+#     assert txn_to_str(target) == txn_to_str(mirrored)
 
-    # Restore initial state
-    cashctrl_ledger.mirror_ledger(target=initial, delete=True)
-    mirrored = cashctrl_ledger.ledger().reset_index(drop=True)
-    assert txn_to_str(initial) == txn_to_str(mirrored)
+#     # Mirror with duplicate transactions and delete=False
+#     new_individual_transaction = individual_transaction.copy()
+#     new_collective_transaction = collective_transaction.copy()
+#     new_individual_transaction['id'].iat[0] = 5
+#     new_collective_transaction['id'].iat[0] = 6
+#     new_collective_transaction['id'].iat[1] = 6
+#     target = pd.concat([
+#         individual_transaction,
+#         new_individual_transaction,
+#         collective_transaction,
+#         new_collective_transaction,
+#     ])
+#     cashctrl_ledger.mirror_ledger(target=target)
+#     mirrored = cashctrl_ledger.ledger().reset_index(drop=True)
+#     assert txn_to_str(target) == txn_to_str(mirrored)
+
+#     # Mirror with alternative transactions and delete=False
+#     target = pd.concat([alt_individual_transaction, alt_collective_transaction])
+#     expected = pd.concat([mirrored, target])
+#     cashctrl_ledger.mirror_ledger(target=target, delete=False)
+#     mirrored = cashctrl_ledger.ledger().reset_index(drop=True)
+#     assert txn_to_str(mirrored) == txn_to_str(expected)
+
+#     # Mirror with delete=False
+#     target = pd.concat([individual_transaction, collective_transaction])
+#     cashctrl_ledger.mirror_ledger(target=target, delete=False)
+#     mirrored = cashctrl_ledger.ledger().reset_index(drop=True)
+#     assert txn_to_str(target) == txn_to_str(mirrored)
+
+#     # Mirror with delete=True
+#     target = pd.concat([individual_transaction, collective_transaction])
+#     cashctrl_ledger.mirror_ledger(target=target)
+#     mirrored = cashctrl_ledger.ledger().reset_index(drop=True)
+#     assert txn_to_str(target) == txn_to_str(mirrored)
+
+#     # Mirror an empty target state
+#     cashctrl_ledger.mirror_ledger(target=pd.DataFrame({}), delete=True)
+#     assert cashctrl_ledger.ledger().empty
+
+#     # Restore initial state
+#     cashctrl_ledger.mirror_ledger(target=initial, delete=True)
+#     mirrored = cashctrl_ledger.ledger().reset_index(drop=True)
+#     assert txn_to_str(initial) == txn_to_str(mirrored)


### PR DESCRIPTION
In this pull request we created a function `_get_ledger_attachments` that find a real attachments that is linked to the ledger entry. 
CashCtrl doesn`t provide us with direct way to retrieve path of file that is linked to the ledger entry.

This function will come in hand for completing the [cashctrl_ledger#7](https://github.com/macxred/cashctrl_ledger/issues/7) issue.

@lasuk Please review the changes and provide feedback or approval for merging.