### PR TITLE
Refactor Ledger Mutators and Tests

### DIFF
--- a/cashctrl_ledger/__init__.py
+++ b/cashctrl_ledger/__init__.py
@@ -9,5 +9,6 @@ Modules:
 
 from .ledger import CashCtrlLedger
 from .nesting import nest, unnest
+from .testing import assert_frame_equal
 from .ledger_utils import df_to_consistent_str
 from .constants import *

--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -285,7 +285,9 @@ class CashCtrlLedger(LedgerEngine):
             df['txn_str'] = [f'{str(date)},{df_to_consistent_str(txn)}' for date, txn in zip(df['date'], df['txn'])]
             return df
         remote = process_ledger(self.ledger())
-        target = process_ledger(self.sanitize_ledger(self.standardize_ledger(target)))
+        target = self.sanitize_ledger(self.standardize_ledger(target))
+        target['date'] = target['date'].ffill()
+        target = process_ledger(target)
         if target['id'].duplicated().any():
             # We expect nesting to combine all rows with the same
             raise ValueError("Non-unique dates in `target` transactions.")

--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -286,6 +286,9 @@ class CashCtrlLedger(LedgerEngine):
             return df
         remote = process_ledger(self.ledger())
         target = process_ledger(self.sanitize_ledger(self.standardize_ledger(target)))
+        if target['id'].duplicated().any():
+            # We expect nesting to combine all rows with the same
+            raise ValueError("Non-unique dates in `target` transactions.")
 
         # Count occurrences of each unique transaction in target and remote,
         # find number of additions and deletions for each unique transaction

--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -383,15 +383,15 @@ class CashCtrlLedger(LedgerEngine):
 
         return StandaloneLedger.standardize_ledger(result)
 
-    def add_ledger_entry(self, entry: pd.DataFrame) -> int:
+    def _map_ledger_entry(self, entry: pd.DataFrame) -> dict:
         """
-        Adds a new ledger entry to the remote CashCtrl instance.
+        Converts a single ledger entry to a data structure for upload to CashCtrl.
 
         Parameters:
-            entry (pd.DataFrame): DataFrame with the ledger schema
+            entry (pd.DataFrame): DataFrame with ledger entry in pyledger schema
 
         Returns:
-            int: The Id of created ledger entry.
+            dict: A data structure to post as json to the CashCtrl REST API.
         """
         entry = StandaloneLedger.standardize_ledger(entry)
 
@@ -430,7 +430,20 @@ class CashCtrlLedger(LedgerEngine):
             }
         else:
             raise ValueError('The ledger entry contains no transaction.')
+        return payload
 
+
+    def add_ledger_entry(self, entry: pd.DataFrame) -> int:
+        """
+        Adds a new ledger entry to the remote CashCtrl instance.
+
+        Parameters:
+            entry (pd.DataFrame): DataFrame with ledger entry in pyledger schema
+
+        Returns:
+            int: The Id of created ledger entry.
+        """
+        payload = self._map_ledger_entry(entry)
         res = self._client.post("journal/create.json", data=payload)
         self._client.invalidate_journal_cache()
         return res['insertId']
@@ -440,50 +453,12 @@ class CashCtrlLedger(LedgerEngine):
         Adds a new ledger entry to the remote CashCtrl instance.
 
         Parameters:
-            entry (pd.DataFrame): DataFrame with the ledger schema
+            entry (pd.DataFrame): DataFrame with ledger entry in pyledger schema
         """
-        entry = StandaloneLedger.standardize_ledger(entry)
-
-        # Individual ledger entry
-        if len(entry) == 1:
-            payload = {
-                'id': entry['id'].iat[0],
-                'dateAdded': entry['date'].iat[0],
-                'amount': entry['amount'].iat[0],
-                'creditId': self._client.account_to_id(entry['account'].iat[0]),
-                'debitId': self._client.account_to_id(entry['counter_account'].iat[0]),
-                'currencyId': None if pd.isna(entry['currency'].iat[0]) else self._client.currency_to_id(entry['currency'].iat[0]),
-                'title': entry['text'].iat[0],
-                'taxId': None if pd.isna(entry['vat_code'].iat[0]) else self._client.tax_code_to_id(entry['vat_code'].iat[0]),
-                'reference': None if pd.isna(entry['document'].iat[0]) else entry['document'].iat[0],
-            }
-
-        # Collective ledger entry
-        elif len(entry) > 1:
-            if entry['id'].nunique() != 1:
-                raise ValueError('Id needs to be unique in all rows of a collective booking.')
-            if entry['currency'].nunique() != 1:
-                raise ValueError("CashCtrl only allows for a single currency in a collective booking.")
-            if entry['date'].nunique() != 1:
-                raise ValueError('Date needs to be unique in all rows of a collective booking.')
-            payload = {
-                'id': entry['id'].iat[0],
-                'dateAdded': entry['date'].iat[0].strftime("%Y-%m-%d"),
-                'currencyId': None if pd.isna(entry['currency'].iat[0]) else self._client.currency_to_id(entry['currency'].iat[0]),
-                'reference': None if pd.isna(entry['document'].iat[0]) else entry['document'].iat[0],
-                'items': [{
-                        'dateAdded': entry['date'].iat[0].strftime("%Y-%m-%d"),
-                        'accountId': self._client.account_to_id(row['account']),
-                        'credit': max(row['amount'], 0),
-                        'debit': max(-row['amount'], 0),
-                        'taxId': None if pd.isna(row['vat_code']) else self._client.tax_code_to_id(row['vat_code']),
-                        'description': row['text'],
-                    } for _, row in entry.iterrows()
-                ]
-            }
-        else:
-            raise ValueError('The ledger entry contains no transaction.')
-
+        payload = self._map_ledger_entry(entry)
+        if entry['id'].nunique() != 1:
+            raise ValueError('Id needs to be unique in all rows of a collective booking.')
+        payload['id'] = entry['id'].iat[0]
         self._client.post("journal/update.json", data=payload)
         self._client.invalidate_journal_cache()
 

--- a/cashctrl_ledger/testing.py
+++ b/cashctrl_ledger/testing.py
@@ -1,3 +1,7 @@
+"""
+Module for functions that help in testing.
+"""
+
 import pandas as pd
 
 def assert_frame_equal(left, right, *args, ignore_index=False, ignore_columns=None, **kwargs):

--- a/cashctrl_ledger/testing.py
+++ b/cashctrl_ledger/testing.py
@@ -1,0 +1,29 @@
+import pandas as pd
+
+def assert_frame_equal(left, right, *args, ignore_index=False, ignore_columns=None, **kwargs):
+    """
+    Extend the pandas method to compare two DataFrames for equality with options to ignore index or specific columns.
+
+    Parameters:
+    left : DataFrame
+        First DataFrame to compare.
+    right : DataFrame
+        Second DataFrame to compare.
+    *args : tuple
+        Additional positional arguments to pass to pandas.testing.assert_frame_equal.
+    ignore_index : bool, default False
+        Whether to ignore the index in the comparison.
+    ignore_columns : list, default None
+        List of column names to ignore (drop) in the comparison.
+    **kwargs : additional keyword arguments
+        Additional arguments to pass to pandas.testing.assert_frame_equal.
+    """
+    if ignore_index:
+        left = left.reset_index(drop=True)
+        right = right.reset_index(drop=True)
+
+    if ignore_columns:
+        left = left.drop(columns=ignore_columns, errors='ignore')
+        right = right.drop(columns=ignore_columns, errors='ignore')
+
+    pd.testing.assert_frame_equal(left, right, *args, **kwargs)

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -6,7 +6,7 @@ from io import StringIO
 from typing import List
 import pytest
 import pandas as pd
-from cashctrl_ledger import CashCtrlLedger, df_to_consistent_str, nest
+from cashctrl_ledger import CashCtrlLedger, df_to_consistent_str, nest, assert_frame_equal
 from pyledger import StandaloneLedger
 from requests.exceptions import RequestException
 
@@ -55,18 +55,19 @@ def test_ledger_accessor_mutators_single_transaction(add_vat_code):
     target = LEDGER_ENTRIES.iloc[[0]]
     id = cashctrl.add_ledger_entry(target)
     remote = cashctrl.ledger()
-    created = remote.loc[remote['id'] == str(id)].reset_index(drop=True)
-    expected = StandaloneLedger.standardize_ledger(target).reset_index(drop=True)
-    pd.testing.assert_frame_equal(created.drop(columns=['id']), expected.drop(columns=['id']))
+    created = remote.loc[remote['id'] == str(id)]
+    expected = StandaloneLedger.standardize_ledger(target)
+    assert_frame_equal(created, expected, ignore_index=True, ignore_columns=['id'])
 
     # Test update the ledger entry
     target = LEDGER_ENTRIES.iloc[[5]].copy()
     target['id'] = id
     cashctrl.update_ledger_entry(target)
     remote = cashctrl.ledger()
-    updated = remote.loc[remote['id'] == str(id)].reset_index(drop=True)
-    expected = StandaloneLedger.standardize_ledger(target).reset_index(drop=True)
-    pd.testing.assert_frame_equal(updated, expected)
+    updated = remote.loc[remote['id'] == str(id)]
+    expected = StandaloneLedger.standardize_ledger(target)
+    assert_frame_equal(updated, expected, ignore_index=True)
+
 
     # TODO: CashCtrl doesn`t allow to convert a single transaction into collective
     # transaction if the single transaction has a taxId assigned. See cashctrl#27.
@@ -79,9 +80,9 @@ def test_ledger_accessor_mutators_single_transaction(add_vat_code):
     target['id'] = id
     cashctrl.update_ledger_entry(target)
     remote = cashctrl.ledger()
-    updated = remote.loc[remote['id'] == str(id)].reset_index(drop=True)
-    expected = StandaloneLedger.standardize_ledger(target).reset_index(drop=True)
-    pd.testing.assert_frame_equal(updated, expected)
+    updated = remote.loc[remote['id'] == str(id)]
+    expected = StandaloneLedger.standardize_ledger(target)
+    assert_frame_equal(updated, expected, ignore_index=True)
 
     # Test delete the created ledger entry
     cashctrl.delete_ledger_entry(id)
@@ -96,9 +97,9 @@ def test_ledger_accessor_mutators_single_transaction_without_VAT():
     target['vat_code'] = None
     id = cashctrl.add_ledger_entry(target)
     remote = cashctrl.ledger()
-    created = remote.loc[remote['id'] == str(id)].reset_index(drop=True)
-    expected = StandaloneLedger.standardize_ledger(target).reset_index(drop=True)
-    pd.testing.assert_frame_equal(created.drop(columns=['id']), expected.drop(columns=['id']))
+    created = remote.loc[remote['id'] == str(id)]
+    expected = StandaloneLedger.standardize_ledger(target)
+    assert_frame_equal(created, expected, ignore_index=True, ignore_columns=['id'])
 
     # Test update the ledger entry
     target = LEDGER_ENTRIES.iloc[[0]].copy()
@@ -106,9 +107,9 @@ def test_ledger_accessor_mutators_single_transaction_without_VAT():
     target['vat_code'] = None
     cashctrl.update_ledger_entry(target)
     remote = cashctrl.ledger()
-    updated = remote.loc[remote['id'] == str(id)].reset_index(drop=True)
-    expected = StandaloneLedger.standardize_ledger(target).reset_index(drop=True)
-    pd.testing.assert_frame_equal(updated, expected)
+    updated = remote.loc[remote['id'] == str(id)]
+    expected = StandaloneLedger.standardize_ledger(target)
+    assert_frame_equal(updated, expected, ignore_index=True)
 
     # Test delete the updated ledger entry
     cashctrl.delete_ledger_entry(id)
@@ -122,18 +123,18 @@ def test_ledger_accessor_mutators_collective_transaction(add_vat_code):
     target = LEDGER_ENTRIES.iloc[[1, 2]]
     id = cashctrl.add_ledger_entry(target)
     remote = cashctrl.ledger()
-    created = remote.loc[remote['id'] == str(id)].reset_index(drop=True)
-    expected = StandaloneLedger.standardize_ledger(target).reset_index(drop=True)
-    pd.testing.assert_frame_equal(created.drop(columns=['id']), expected.drop(columns=['id']))
+    created = remote.loc[remote['id'] == str(id)]
+    expected = StandaloneLedger.standardize_ledger(target)
+    assert_frame_equal(created, expected, ignore_index=True, ignore_columns=['id'])
 
     # Test update the ledger entry
     target = LEDGER_ENTRIES.iloc[[3, 4]].copy()
     target['id'] = id
     cashctrl.update_ledger_entry(target)
     remote = cashctrl.ledger()
-    updated = remote.loc[remote['id'] == str(id)].reset_index(drop=True)
-    expected = StandaloneLedger.standardize_ledger(target).reset_index(drop=True)
-    pd.testing.assert_frame_equal(updated, expected)
+    updated = remote.loc[remote['id'] == str(id)]
+    expected = StandaloneLedger.standardize_ledger(target)
+    assert_frame_equal(updated, expected, ignore_index=True)
 
     # Test replace with an individual ledger entry
     target = LEDGER_ENTRIES.iloc[[0]].copy()
@@ -141,9 +142,9 @@ def test_ledger_accessor_mutators_collective_transaction(add_vat_code):
     target['vat_code'] = None
     cashctrl.update_ledger_entry(target)
     remote = cashctrl.ledger()
-    updated = remote.loc[remote['id'] == str(id)].reset_index(drop=True)
-    expected = StandaloneLedger.standardize_ledger(target).reset_index(drop=True)
-    pd.testing.assert_frame_equal(updated, expected)
+    updated = remote.loc[remote['id'] == str(id)]
+    expected = StandaloneLedger.standardize_ledger(target)
+    assert_frame_equal(updated, expected, ignore_index=True)
 
     # Test delete the updated ledger entry
     cashctrl.delete_ledger_entry(id)
@@ -158,9 +159,10 @@ def test_ledger_accessor_mutators_collective_transaction_without_vat():
     target['vat_code'] = None
     id = cashctrl.add_ledger_entry(target)
     remote = cashctrl.ledger()
-    created = remote.loc[remote['id'] == str(id)].reset_index(drop=True)
-    expected = StandaloneLedger.standardize_ledger(target).reset_index(drop=True)
-    pd.testing.assert_frame_equal(created.drop(columns=['id']), expected.drop(columns=['id']))
+    created = remote.loc[remote['id'] == str(id)]
+    expected = StandaloneLedger.standardize_ledger(target)
+    assert_frame_equal(created, expected, ignore_index=True, ignore_columns=['id'])
+
 
     # Test update the ledger entry
     target = LEDGER_ENTRIES.iloc[[3, 4]].copy()
@@ -168,9 +170,9 @@ def test_ledger_accessor_mutators_collective_transaction_without_vat():
     target['vat_code'] = None
     cashctrl.update_ledger_entry(target)
     remote = cashctrl.ledger()
-    updated = remote.loc[remote['id'] == str(id)].reset_index(drop=True)
-    expected = StandaloneLedger.standardize_ledger(target).reset_index(drop=True)
-    pd.testing.assert_frame_equal(updated, expected)
+    updated = remote.loc[remote['id'] == str(id)]
+    expected = StandaloneLedger.standardize_ledger(target)
+    assert_frame_equal(updated, expected, ignore_index=True)
 
     # Test delete the updated ledger entry
     cashctrl.delete_ledger_entry(id)

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -52,7 +52,7 @@ def test_ledger_accessor_mutators_single_transaction(add_vat_code):
     cashctrl = CashCtrlLedger()
 
     # Test adding a ledger entry
-    target = LEDGER_ENTRIES.iloc[[0]]
+    target = LEDGER_ENTRIES.query('id == 1')
     id = cashctrl.add_ledger_entry(target)
     remote = cashctrl.ledger()
     created = remote.loc[remote['id'] == str(id)]
@@ -60,7 +60,7 @@ def test_ledger_accessor_mutators_single_transaction(add_vat_code):
     assert_frame_equal(created, expected, ignore_index=True, ignore_columns=['id'])
 
     # Test update the ledger entry
-    target = LEDGER_ENTRIES.iloc[[5]].copy()
+    target = LEDGER_ENTRIES.query('id == 4').copy()
     target['id'] = id
     cashctrl.update_ledger_entry(target)
     remote = cashctrl.ledger()
@@ -76,7 +76,7 @@ def test_ledger_accessor_mutators_single_transaction(add_vat_code):
     cashctrl.update_ledger_entry(target)
 
     # Test replace with an collective ledger entry
-    target = LEDGER_ENTRIES.iloc[[1, 2]].copy()
+    target = LEDGER_ENTRIES.query('id == 2').copy()
     target['id'] = id
     cashctrl.update_ledger_entry(target)
     remote = cashctrl.ledger()
@@ -93,7 +93,7 @@ def test_ledger_accessor_mutators_single_transaction_without_VAT():
     cashctrl = CashCtrlLedger()
 
     # Test adding a ledger entry without VAT code
-    target = LEDGER_ENTRIES.iloc[[5]].copy()
+    target = LEDGER_ENTRIES.query('id == 4').copy()
     target['vat_code'] = None
     id = cashctrl.add_ledger_entry(target)
     remote = cashctrl.ledger()
@@ -102,7 +102,7 @@ def test_ledger_accessor_mutators_single_transaction_without_VAT():
     assert_frame_equal(created, expected, ignore_index=True, ignore_columns=['id'])
 
     # Test update the ledger entry
-    target = LEDGER_ENTRIES.iloc[[0]].copy()
+    target = LEDGER_ENTRIES.query('id == 1').copy()
     target['id'] = id
     target['vat_code'] = None
     cashctrl.update_ledger_entry(target)
@@ -120,7 +120,7 @@ def test_ledger_accessor_mutators_collective_transaction(add_vat_code):
     cashctrl = CashCtrlLedger()
 
     # Test adding a ledger entry
-    target = LEDGER_ENTRIES.iloc[[1, 2]]
+    target = LEDGER_ENTRIES.query('id == 2')
     id = cashctrl.add_ledger_entry(target)
     remote = cashctrl.ledger()
     created = remote.loc[remote['id'] == str(id)]
@@ -128,7 +128,7 @@ def test_ledger_accessor_mutators_collective_transaction(add_vat_code):
     assert_frame_equal(created, expected, ignore_index=True, ignore_columns=['id'])
 
     # Test update the ledger entry
-    target = LEDGER_ENTRIES.iloc[[3, 4]].copy()
+    target = LEDGER_ENTRIES.query('id == 3').copy()
     target['id'] = id
     cashctrl.update_ledger_entry(target)
     remote = cashctrl.ledger()
@@ -155,7 +155,7 @@ def test_ledger_accessor_mutators_collective_transaction_without_vat():
     cashctrl = CashCtrlLedger()
 
     # Test adding a ledger entry
-    target = LEDGER_ENTRIES.iloc[[1, 2]].copy()
+    target = LEDGER_ENTRIES.query('id == 2').copy()
     target['vat_code'] = None
     id = cashctrl.add_ledger_entry(target)
     remote = cashctrl.ledger()
@@ -165,7 +165,7 @@ def test_ledger_accessor_mutators_collective_transaction_without_vat():
 
 
     # Test update the ledger entry
-    target = LEDGER_ENTRIES.iloc[[3, 4]].copy()
+    target = LEDGER_ENTRIES.query('id == 3').copy()
     target['id'] = id
     target['vat_code'] = None
     cashctrl.update_ledger_entry(target)
@@ -182,7 +182,7 @@ def test_ledger_accessor_mutators_collective_transaction_without_vat():
 def test_add_ledger_with_non_existing_vat():
     # Adding a ledger entry with non existing VAT code should raise an error
     cashctrl = CashCtrlLedger()
-    target = LEDGER_ENTRIES.iloc[[0]].copy()
+    target = LEDGER_ENTRIES.query('id == 1').copy()
     target['vat_code'].iat[0] = 'Test_Non_Existent_VAT_code'
     with pytest.raises(ValueError, match='No id found for tax code'):
         cashctrl.add_ledger_entry(target)
@@ -190,7 +190,7 @@ def test_add_ledger_with_non_existing_vat():
 def test_add_ledger_with_non_existing_account():
     # Adding a ledger entry with non existing account should raise an error
     cashctrl = CashCtrlLedger()
-    target = LEDGER_ENTRIES.iloc[[0]].copy()
+    target = LEDGER_ENTRIES.query('id == 1').copy()
     target['account'] = 33333
     with pytest.raises(ValueError, match='No id found for account'):
         cashctrl.add_ledger_entry(target)
@@ -198,31 +198,31 @@ def test_add_ledger_with_non_existing_account():
 def test_add_ledger_with_non_existing_currency():
     # Adding a ledger entry with non existing currency code should raise an error
     cashctrl = CashCtrlLedger()
-    target = LEDGER_ENTRIES.iloc[[0]].copy()
+    target = LEDGER_ENTRIES.query('id == 1').copy()
     target['currency'] = 'Non_Existent_Currency'
     with pytest.raises(ValueError, match='No id found for currency'):
         cashctrl.add_ledger_entry(target)
 
 def test_update_ledger_with_illegal_attributes(add_vat_code):
     cashctrl = CashCtrlLedger()
-    id = cashctrl.add_ledger_entry(LEDGER_ENTRIES.iloc[[0]])
+    id = cashctrl.add_ledger_entry(LEDGER_ENTRIES.query('id == 1'))
 
     # Updating a ledger with non existent VAT code should raise an error
-    target = LEDGER_ENTRIES.iloc[[0]].copy()
+    target = LEDGER_ENTRIES.query('id == 1').copy()
     target['id'] = id
     target['vat_code'] = 'Test_Non_Existent_VAT_code'
     with pytest.raises(ValueError, match='No id found for tax code'):
         cashctrl.update_ledger_entry(target)
 
     # Updating a ledger with non existent account code should raise an error
-    target = LEDGER_ENTRIES.iloc[[0]].copy()
+    target = LEDGER_ENTRIES.query('id == 1').copy()
     target['id'] = id
     target['account'].iat[0] = 333333
     with pytest.raises(ValueError, match='No id found for account'):
         cashctrl.update_ledger_entry(target)
 
     # Updating a ledger with non existent currency code should raise an error
-    target = LEDGER_ENTRIES.iloc[[0]].copy()
+    target = LEDGER_ENTRIES.query('id == 1').copy()
     target['id'] = id
     target['currency'].iat[0] = 'Non_Existent_Currency'
     with pytest.raises(ValueError, match='No id found for currency'):
@@ -234,7 +234,7 @@ def test_update_ledger_with_illegal_attributes(add_vat_code):
 # Updating a non-existent ledger should raise an error
 def test_update_non_existent_ledger():
     cashctrl = CashCtrlLedger()
-    target = LEDGER_ENTRIES.iloc[[0]].copy()
+    target = LEDGER_ENTRIES.query('id == 1').copy()
     target['id'] = 999999
     with pytest.raises(RequestException):
         cashctrl.update_ledger_entry(target)
@@ -249,7 +249,7 @@ def test_mirror_ledger(add_vat_code):
     cashctrl = CashCtrlLedger()
 
     # Mirror with one single and one collective transaction
-    target = LEDGER_ENTRIES.iloc[[0, 1, 2]]
+    target = LEDGER_ENTRIES.query('id in [1, 2]')
     cashctrl.mirror_ledger(target=target, delete=True)
     expected = StandaloneLedger.standardize_ledger(target)
     mirrored = cashctrl.ledger()
@@ -257,10 +257,10 @@ def test_mirror_ledger(add_vat_code):
 
     # Mirror with duplicate transactions and delete=False
     target = pd.concat([
-        LEDGER_ENTRIES.iloc[[0]],
-        LEDGER_ENTRIES.iloc[[0]].assign(id=5),
-        LEDGER_ENTRIES.iloc[[1, 2]].assign(id=6),
-        LEDGER_ENTRIES.iloc[[1, 2]]
+        LEDGER_ENTRIES.query('id == 1'),
+        LEDGER_ENTRIES.query('id == 1').assign(id=5),
+        LEDGER_ENTRIES.query('id == 2').assign(id=6),
+        LEDGER_ENTRIES.query('id == 2')
     ])
     cashctrl.mirror_ledger(target=target)
     expected = StandaloneLedger.standardize_ledger(target)
@@ -268,20 +268,20 @@ def test_mirror_ledger(add_vat_code):
     assert txn_to_str(mirrored) == txn_to_str(expected)
 
     # Mirror with alternative transactions and delete=False
-    target = LEDGER_ENTRIES.iloc[[5, 3, 4]]
+    target = LEDGER_ENTRIES.query('id in [3, 4]')
     cashctrl.mirror_ledger(target=target, delete=False)
     expected = pd.concat([mirrored, StandaloneLedger.standardize_ledger(target)])
     mirrored = cashctrl.ledger()
     assert txn_to_str(mirrored) == txn_to_str(expected)
 
     # Mirror existing transactions with delete=False has no impact
-    target = LEDGER_ENTRIES.iloc[[0, 1, 2]]
+    target = LEDGER_ENTRIES.query('id in [1, 2]')
     cashctrl.mirror_ledger(target=target, delete=False)
     mirrored = cashctrl.ledger()
     assert txn_to_str(mirrored) == txn_to_str(expected)
 
     # Mirror with delete=True
-    target = LEDGER_ENTRIES.iloc[[0, 1, 2]]
+    target = LEDGER_ENTRIES.query('id in [1, 2]')
     cashctrl.mirror_ledger(target=target)
     mirrored = cashctrl.ledger()
     expected = StandaloneLedger.standardize_ledger(target)

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -5,55 +5,6 @@ from cashctrl_ledger import CashCtrlLedger, df_to_consistent_str, nest
 from pyledger import StandaloneLedger
 from requests.exceptions import RequestException
 
-@pytest.fixture(scope="module")
-def tmp_path_for_module(tmp_path_factory):
-    return tmp_path_factory.mktemp("temp")
-
-@pytest.fixture(scope="module")
-def mock_directory(tmp_path_for_module):
-    """Create a temporary directory, populate with files and folders."""
-    tmp_path = tmp_path_for_module
-    (tmp_path / 'file1.txt').write_text("This is a text file.")
-    subdir = tmp_path / 'subdir'
-    subdir.mkdir(exist_ok=True)
-    (subdir / 'file2.txt').write_text("A Text file in a subdirectory.")
-    return tmp_path
-
-@pytest.fixture(scope="module")
-def files(mock_directory):
-    """Create a CachedCashCtrlClient, populate with files and folders."""
-    cc_client = CashCtrlLedger()
-    initial_files = cc_client._client.list_files()
-    cc_client._client.mirror_directory(mock_directory, delete_files=False)
-    updated_files = cc_client._client.list_files()
-    created_ids = set(updated_files['id']).difference(initial_files['id'])
-
-    # return created files
-    yield updated_files[updated_files['id'].isin(created_ids)]
-
-    # Delete files added in the test
-    params = { 'ids': ','.join(str(i) for i in created_ids), 'force': True }
-    cc_client._client.post("file/delete.json", params=params)
-
-@pytest.fixture(scope="module")
-def ledger_ids():
-    """Populate remote ledger with three new entries and return their ids in a list."""
-    entry = pd.DataFrame({
-        'date': ['2024-05-24'],
-        'account': [2270],
-        'counter_account': [2210],
-        'amount': [100],
-        'currency': ['CHF'],
-        'text': ['test entry'],
-    })
-    engine = CashCtrlLedger()
-    ledger_ids = [engine.add_ledger_entry(entry) for _ in range(3)]
-
-    yield ledger_ids
-
-    # Restore original ledger state
-    engine.delete_ledger_entry(list(map(str, ledger_ids)))
-
 @pytest.fixture(scope="session")
 def add_vat_code():
     # Creates VAT code
@@ -366,25 +317,3 @@ def test_mirror_ledger(add_vat_code):
     cashctrl_ledger.mirror_ledger(target=initial, delete=True)
     mirrored = cashctrl_ledger.ledger().reset_index(drop=True)
     assert txn_to_str(initial) == txn_to_str(mirrored)
-
-def test_get_ledger_attachments(files, ledger_ids):
-    def sort_dict_values(items):
-        return {key: value.sort() for key, value in items.items()}
-    engine = CashCtrlLedger()
-    initial = engine._get_ledger_attachments()
-
-    engine._client.post("journal/update_attachments.json", data={'id': ledger_ids[0], 'fileIds': files['id'].iat[0]})
-    engine._client.invalidate_journal_cache()
-    expected = initial | {ledger_ids[0]: ['/file1.txt']}
-    assert engine._get_ledger_attachments() == expected
-
-    engine._client.post("journal/update_attachments.json", data={'id': ledger_ids[1], 'fileIds': files['id'].iat[1]})
-    engine._client.invalidate_journal_cache()
-    expected = initial | {ledger_ids[0]: ['/file1.txt'], ledger_ids[1]: ['/subdir/file2.txt']}
-    assert engine._get_ledger_attachments() == expected
-
-    file_ids = f'{files['id'].iat[0]},{files['id'].iat[1]}'
-    engine._client.post("journal/update_attachments.json", data={'id': ledger_ids[1], 'fileIds': file_ids})
-    engine._client.invalidate_journal_cache()
-    expected = initial | {ledger_ids[0]: ['/file1.txt'], ledger_ids[1]:  ['/file1.txt', '/subdir/file2.txt']}
-    assert sort_dict_values(engine._get_ledger_attachments()) == sort_dict_values(expected)

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -1,3 +1,7 @@
+"""
+Unit tests for ledger accessors, mutators and mirroring.
+"""
+
 from io import StringIO
 from typing import List
 import pytest

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -32,9 +32,9 @@ def ledger_entries():
          1, 2024-05-24, 2270,            2210,      CHF,    100, Test_VAT_code, pytest single transaction 1,      /file1.txt
          2, 2024-05-24, 2210,                ,      USD,   -100, Test_VAT_code, pytest collective txn 1 - line 1, /subdir/file2.txt
          2, 2024-05-24, 2270,                ,      USD,    100, Test_VAT_code, pytest collective txn 1 - line 2, /subdir/file2.txt
-         3, 2024-04-24, 2210,                ,      USD,   -200, Test_VAT_code, pytest collective txn 2 - line 1, /document-col-alt.pdf
-         3, 2024-04-24, 2270,                ,      USD,    200, Test_VAT_code, pytest collective txn 2 - line 2, /document-col-alt.pdf
-         4, 2024-05-24, 2270,            2210,      CHF,    100, Test_VAT_code, pytest single transaction 2,      /document-alt.pdf
+         3, 2024-04-24, 2210,                ,      EUR,   -200, Test_VAT_code, pytest collective txn 2 - line 1, /document-col-alt.pdf
+         3, 2024-04-24, 2270,                ,      EUR,    200, Test_VAT_code, pytest collective txn 2 - line 2, /document-col-alt.pdf
+         4, 2024-05-24, 2270,            2210,      CHF,    300, Test_VAT_code, pytest single transaction 2,      /document-alt.pdf
     """
     return pd.read_csv(StringIO(LEDGER_CSV), skipinitialspace=True)
 
@@ -45,246 +45,242 @@ def txn_to_str(df: pd.DataFrame) -> List[str]:
     return result.sort()
 
 def test_ledger_accessor_mutators_single_transaction(add_vat_code, ledger_entries):
-    cashctrl_ledger = CashCtrlLedger()
+    cashctrl = CashCtrlLedger()
 
     # Test adding a ledger entry
     target = ledger_entries.iloc[[0]]
-    initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    cashctrl_ledger.add_ledger_entry(target)
-    updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
-    created = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
-    expected = StandaloneLedger.standardize_ledger(target)
+    id = cashctrl.add_ledger_entry(target)
+    remote = cashctrl.ledger()
+    created = remote.loc[remote['id'] == str(id)].reset_index(drop=True)
+    expected = StandaloneLedger.standardize_ledger(target).reset_index(drop=True)
     pd.testing.assert_frame_equal(created.drop(columns=['id']), expected.drop(columns=['id']))
 
-    # Test delete the created ledger entry
-    cashctrl_ledger.delete_ledger_entry(ids=created['id'].iat[0])
-    ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    assert created['id'].iat[0] not in ledger['id']
-
-    # Test adding a ledger entry without VAT code
-    initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    new_entry = ledger_entries.iloc[[0]].copy()
-    new_entry['vat_code'] = None
-    new_entry['text'] = 'Ledger entry without VAT'
-    cashctrl_ledger.add_ledger_entry(entry=new_entry)
-    updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
-    created = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
-    expected = StandaloneLedger.standardize_ledger(new_entry)
-    pd.testing.assert_frame_equal(created.drop(columns=['id']), expected.drop(columns=['id']))
-
-    # Test update a ledger entry
-    initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    new_entry = ledger_entries.iloc[[0]].copy()
-    new_entry['amount'].iat[0] = 300
-    new_entry['id'] = created['id'].iat[0]
-    cashctrl_ledger.update_ledger_entry(entry=new_entry)
-    updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
-    updated = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
-    expected = StandaloneLedger.standardize_ledger(new_entry)
+    # Test update the ledger entry
+    target = ledger_entries.iloc[[5]].copy()
+    target['id'] = id
+    cashctrl.update_ledger_entry(target)
+    remote = cashctrl.ledger()
+    updated = remote.loc[remote['id'] == str(id)].reset_index(drop=True)
+    expected = StandaloneLedger.standardize_ledger(target).reset_index(drop=True)
     pd.testing.assert_frame_equal(updated, expected)
 
     # TODO: CashCtrl doesn`t allow to convert a single transaction into collective
-    # transaction if the single transaction has a taxId assigned. Tracked as cashctrl_ledger#27.
+    # transaction if the single transaction has a taxId assigned. See cashctrl#27.
     # As a workaround, we reset the taxId manually before update with a collective transaction
-    new_entry['vat_code'] = None
-    cashctrl_ledger.update_ledger_entry(entry=new_entry)
+    target['vat_code'] = None
+    cashctrl.update_ledger_entry(target)
 
     # Test replace with an collective ledger entry
-    initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    new_entry = ledger_entries.iloc[[1, 2]].copy()
-    new_entry['id'] = created['id'].iat[0]
-    cashctrl_ledger.update_ledger_entry(entry=new_entry)
-    updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
-    updated = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
-    expected = StandaloneLedger.standardize_ledger(new_entry)
-    pd.testing.assert_frame_equal(updated.drop(columns=['id']).reset_index(drop=True), expected.drop(columns=['id']).reset_index(drop=True), check_column_type=False)
-
-    # Test delete the updated ledger entry
-    cashctrl_ledger.delete_ledger_entry(ids=created['id'].iat[0])
-    ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    assert created['id'].iat[0] not in ledger['id']
-
-def test_ledger_accessor_mutators_collective_transaction(add_vat_code, ledger_entries):
-    cashctrl_ledger = CashCtrlLedger()
-
-    # Test adding a ledger entry
-    initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    target = ledger_entries.iloc[[1, 2]]
-    cashctrl_ledger.add_ledger_entry(target)
-    updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
-    created = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
-    expected = StandaloneLedger.standardize_ledger(target)
-    pd.testing.assert_frame_equal(created.drop(columns=['id']).reset_index(drop=True), expected.drop(columns=['id']).reset_index(drop=True))
+    target = ledger_entries.iloc[[1, 2]].copy()
+    target['id'] = id
+    cashctrl.update_ledger_entry(target)
+    remote = cashctrl.ledger()
+    updated = remote.loc[remote['id'] == str(id)].reset_index(drop=True)
+    expected = StandaloneLedger.standardize_ledger(target).reset_index(drop=True)
+    pd.testing.assert_frame_equal(updated, expected)
 
     # Test delete the created ledger entry
-    cashctrl_ledger.delete_ledger_entry(ids=created['id'].iat[0])
-    ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    assert created['id'].iat[0] not in ledger['id']
+    cashctrl.delete_ledger_entry(id)
+    remote = cashctrl.ledger()
+    assert id not in remote['id']
 
-    # Test adding a ledger entry without VAT
-    initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    new_entry = ledger_entries.iloc[[1, 2]].copy()
-    new_entry['vat_code'] = None
-    cashctrl_ledger.add_ledger_entry(entry=new_entry)
-    updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
-    created = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
-    expected = StandaloneLedger.standardize_ledger(new_entry)
-    pd.testing.assert_frame_equal(created.drop(columns=['id']).reset_index(drop=True), expected.drop(columns=['id']).reset_index(drop=True))
+def test_ledger_accessor_mutators_single_transaction_without_VAT(ledger_entries):
+    cashctrl = CashCtrlLedger()
 
-    # Test update a ledger entry
-    initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    new_entry = ledger_entries.iloc[[1, 2]].copy()
-    new_entry['amount'].iat[0] = 300
-    new_entry['amount'].iat[1] = -300
-    new_entry['id'] = created['id'].iat[0]
-    cashctrl_ledger.update_ledger_entry(entry=new_entry)
-    updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
-    updated = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
-    expected = StandaloneLedger.standardize_ledger(new_entry)
-    pd.testing.assert_frame_equal(updated.reset_index(drop=True), expected.reset_index(drop=True))
+    # Test adding a ledger entry without VAT code
+    target = ledger_entries.iloc[[5]].copy()
+    target['vat_code'] = None
+    id = cashctrl.add_ledger_entry(target)
+    remote = cashctrl.ledger()
+    created = remote.loc[remote['id'] == str(id)].reset_index(drop=True)
+    expected = StandaloneLedger.standardize_ledger(target).reset_index(drop=True)
+    pd.testing.assert_frame_equal(created.drop(columns=['id']), expected.drop(columns=['id']))
 
-    # Test replace with an individual ledger entry
-    initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    new_entry = ledger_entries.iloc[[0]].copy()
-    new_entry['id'] = created['id'].iat[0]
-    new_entry['vat_code'] = None
-    cashctrl_ledger.update_ledger_entry(entry=new_entry)
-    updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
-    updated = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
-    expected = StandaloneLedger.standardize_ledger(new_entry)
-    pd.testing.assert_frame_equal(updated.reset_index(drop=True), expected.reset_index(drop=True))
+    # Test update the ledger entry
+    target = ledger_entries.iloc[[0]].copy()
+    target['id'] = id
+    target['vat_code'] = None
+    cashctrl.update_ledger_entry(target)
+    remote = cashctrl.ledger()
+    updated = remote.loc[remote['id'] == str(id)].reset_index(drop=True)
+    expected = StandaloneLedger.standardize_ledger(target).reset_index(drop=True)
+    pd.testing.assert_frame_equal(updated, expected)
 
     # Test delete the updated ledger entry
-    cashctrl_ledger.delete_ledger_entry(ids=created['id'].iat[0])
-    ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    assert created['id'].iat[0] not in ledger['id']
+    cashctrl.delete_ledger_entry(id)
+    remote = cashctrl.ledger()
+    assert id not in remote['id']
 
-# Tests for addition logic edge cases
-def test_add_ledger_with_non_existent_vat(ledger_entries):
-    cashctrl_ledger = CashCtrlLedger()
+def test_ledger_accessor_mutators_collective_transaction(add_vat_code, ledger_entries):
+    cashctrl = CashCtrlLedger()
 
-    # Adding a ledger with non existent VAT code should raise an error
-    entry = ledger_entries.iloc[[0]].copy()
-    entry['vat_code'].iat[0] = 'Test_Non_Existent_VAT_code'
+    # Test adding a ledger entry
+    target = ledger_entries.iloc[[1, 2]]
+    id = cashctrl.add_ledger_entry(target)
+    remote = cashctrl.ledger()
+    created = remote.loc[remote['id'] == str(id)].reset_index(drop=True)
+    expected = StandaloneLedger.standardize_ledger(target).reset_index(drop=True)
+    pd.testing.assert_frame_equal(created.drop(columns=['id']), expected.drop(columns=['id']))
+
+    # Test update the ledger entry
+    target = ledger_entries.iloc[[3, 4]].copy()
+    target['id'] = id
+    cashctrl.update_ledger_entry(target)
+    remote = cashctrl.ledger()
+    updated = remote.loc[remote['id'] == str(id)].reset_index(drop=True)
+    expected = StandaloneLedger.standardize_ledger(target).reset_index(drop=True)
+    pd.testing.assert_frame_equal(updated, expected)
+
+    # Test replace with an individual ledger entry
+    target = ledger_entries.iloc[[0]].copy()
+    target['id'] = id
+    target['vat_code'] = None
+    cashctrl.update_ledger_entry(target)
+    remote = cashctrl.ledger()
+    updated = remote.loc[remote['id'] == str(id)].reset_index(drop=True)
+    expected = StandaloneLedger.standardize_ledger(target).reset_index(drop=True)
+    pd.testing.assert_frame_equal(updated, expected)
+
+    # Test delete the updated ledger entry
+    cashctrl.delete_ledger_entry(id)
+    remote = cashctrl.ledger()
+    assert id not in remote['id']
+
+def test_ledger_accessor_mutators_collective_transaction_without_vat(ledger_entries):
+    cashctrl = CashCtrlLedger()
+
+    # Test adding a ledger entry
+    target = ledger_entries.iloc[[1, 2]].copy()
+    target['vat_code'] = None
+    id = cashctrl.add_ledger_entry(target)
+    remote = cashctrl.ledger()
+    created = remote.loc[remote['id'] == str(id)].reset_index(drop=True)
+    expected = StandaloneLedger.standardize_ledger(target).reset_index(drop=True)
+    pd.testing.assert_frame_equal(created.drop(columns=['id']), expected.drop(columns=['id']))
+
+    # Test update the ledger entry
+    target = ledger_entries.iloc[[3, 4]].copy()
+    target['id'] = id
+    target['vat_code'] = None
+    cashctrl.update_ledger_entry(target)
+    remote = cashctrl.ledger()
+    updated = remote.loc[remote['id'] == str(id)].reset_index(drop=True)
+    expected = StandaloneLedger.standardize_ledger(target).reset_index(drop=True)
+    pd.testing.assert_frame_equal(updated, expected)
+
+    # Test delete the updated ledger entry
+    cashctrl.delete_ledger_entry(id)
+    remote = cashctrl.ledger()
+    assert id not in remote['id']
+
+def test_add_ledger_with_non_existing_vat(ledger_entries):
+    # Adding a ledger entry with non existing VAT code should raise an error
+    cashctrl = CashCtrlLedger()
+    target = ledger_entries.iloc[[0]].copy()
+    target['vat_code'].iat[0] = 'Test_Non_Existent_VAT_code'
     with pytest.raises(ValueError, match='No id found for tax code'):
-        cashctrl_ledger.add_ledger_entry(entry=entry)
+        cashctrl.add_ledger_entry(target)
 
-    # Adding a ledger with non existent account code should raise an error
-    entry = ledger_entries.iloc[[0]].copy()
-    entry['account'].iat[0] = 33333
+def test_add_ledger_with_non_existing_account(ledger_entries):
+    # Adding a ledger entry with non existing account should raise an error
+    cashctrl = CashCtrlLedger()
+    target = ledger_entries.iloc[[0]].copy()
+    target['account'] = 33333
     with pytest.raises(ValueError, match='No id found for account'):
-        cashctrl_ledger.add_ledger_entry(entry=entry)
+        cashctrl.add_ledger_entry(target)
 
-    # Adding a ledger with non existent currency code should raise an error
-    entry = ledger_entries.iloc[[0]].copy()
-    entry['currency'].iat[0] = 'Non_Existent_Currency'
+def test_add_ledger_with_non_existing_currency(ledger_entries):
+    # Adding a ledger entry with non existing currency code should raise an error
+    cashctrl = CashCtrlLedger()
+    target = ledger_entries.iloc[[0]].copy()
+    target['currency'] = 'Non_Existent_Currency'
     with pytest.raises(ValueError, match='No id found for currency'):
-        cashctrl_ledger.add_ledger_entry(entry=entry)
+        cashctrl.add_ledger_entry(target)
 
-# Tests for updating logic edge cases
-def test_update_ledger_with_edge_cases(add_vat_code, ledger_entries):
-    cashctrl_ledger = CashCtrlLedger()
-
-    initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    cashctrl_ledger.add_ledger_entry(ledger_entries.iloc[[0]])
-    updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
-    created = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
+def test_update_ledger_with_illegal_attributes(add_vat_code, ledger_entries):
+    cashctrl = CashCtrlLedger()
+    id = cashctrl.add_ledger_entry(ledger_entries.iloc[[0]])
 
     # Updating a ledger with non existent VAT code should raise an error
-    new_entry = ledger_entries.iloc[[0]].copy()
-    new_entry['id'] = created['id'].iat[0]
-    new_entry['vat_code'].iat[0] = 'Test_Non_Existent_VAT_code'
+    target = ledger_entries.iloc[[0]].copy()
+    target['id'] = id
+    target['vat_code'] = 'Test_Non_Existent_VAT_code'
     with pytest.raises(ValueError, match='No id found for tax code'):
-        cashctrl_ledger.update_ledger_entry(entry=new_entry)
+        cashctrl.update_ledger_entry(target)
 
     # Updating a ledger with non existent account code should raise an error
-    new_entry = ledger_entries.iloc[[0]].copy()
-    new_entry['id'] = created['id'].iat[0]
-    new_entry['account'].iat[0] = 333333
+    target = ledger_entries.iloc[[0]].copy()
+    target['id'] = id
+    target['account'].iat[0] = 333333
     with pytest.raises(ValueError, match='No id found for account'):
-        cashctrl_ledger.update_ledger_entry(entry=new_entry)
+        cashctrl.update_ledger_entry(target)
 
     # Updating a ledger with non existent currency code should raise an error
-    new_entry = ledger_entries.iloc[[0]].copy()
-    new_entry['id'] = created['id'].iat[0]
-    new_entry['currency'].iat[0] = 'CURRENCY'
+    target = ledger_entries.iloc[[0]].copy()
+    target['id'] = id
+    target['currency'].iat[0] = 'Non_Existent_Currency'
     with pytest.raises(ValueError, match='No id found for currency'):
-        cashctrl_ledger.update_ledger_entry(entry=new_entry)
+        cashctrl.update_ledger_entry(target)
 
     # Delete the ledger entry created above
-    cashctrl_ledger.delete_ledger_entry(ids=created['id'].iat[0])
-    ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    assert created['id'].iat[0] not in ledger['id']
+    cashctrl.delete_ledger_entry(id)
 
 # Updating a non-existent ledger should raise an error
 def test_update_non_existent_ledger(ledger_entries):
-    cashctrl_ledger = CashCtrlLedger()
-    entry = ledger_entries.iloc[[0]].copy()
-    entry['id'] = 999999
+    cashctrl = CashCtrlLedger()
+    target = ledger_entries.iloc[[0]].copy()
+    target['id'] = 999999
     with pytest.raises(RequestException):
-        cashctrl_ledger.update_ledger_entry(entry=entry)
+        cashctrl.update_ledger_entry(target)
 
 # Deleting a non-existent ledger should raise an error
 def test_delete_non_existent_ledger():
-    cashctrl_ledger = CashCtrlLedger()
+    cashctrl = CashCtrlLedger()
     with pytest.raises(RequestException):
-        cashctrl_ledger.delete_ledger_entry(ids='non-existent')
+        cashctrl.delete_ledger_entry(ids='non-existent')
 
 def test_mirror_ledger(add_vat_code, ledger_entries):
-    cashctrl_ledger = CashCtrlLedger()
+    cashctrl = CashCtrlLedger()
 
     # Mirror with one single and one collective transaction
-    target = ledger_entries.iloc[[0, 1, 2]].copy()
-    cashctrl_ledger.mirror_ledger(target=target)
-    mirrored = cashctrl_ledger.ledger()
-    assert txn_to_str(target) == txn_to_str(mirrored)
+    target = ledger_entries.iloc[[0, 1, 2]]
+    cashctrl.mirror_ledger(target=target, delete=True)
+    expected = StandaloneLedger.standardize_ledger(target)
+    mirrored = cashctrl.ledger()
+    assert txn_to_str(mirrored) == txn_to_str(expected)
 
     # Mirror with duplicate transactions and delete=False
-    new_individual_transaction = ledger_entries.iloc[[0]].copy()
-    new_collective_transaction = ledger_entries.iloc[[1, 2]].copy()
-    new_individual_transaction['id'] = 5
-    new_collective_transaction['id'] = 6
     target = pd.concat([
         ledger_entries.iloc[[0]],
-        new_individual_transaction,
-        ledger_entries.iloc[[1, 2]],
-        new_collective_transaction,
+        ledger_entries.iloc[[0]].assign(id=5),
+        ledger_entries.iloc[[1, 2]].assign(id=6),
+        ledger_entries.iloc[[1, 2]]
     ])
-    cashctrl_ledger.mirror_ledger(target=target)
-    mirrored = cashctrl_ledger.ledger().reset_index(drop=True)
+    cashctrl.mirror_ledger(target=target)
     expected = StandaloneLedger.standardize_ledger(target)
+    mirrored = cashctrl.ledger()
     assert txn_to_str(mirrored) == txn_to_str(expected)
 
     # Mirror with alternative transactions and delete=False
     target = ledger_entries.iloc[[5, 3, 4]]
+    cashctrl.mirror_ledger(target=target, delete=False)
     expected = pd.concat([mirrored, StandaloneLedger.standardize_ledger(target)])
-    cashctrl_ledger.mirror_ledger(target=target, delete=False)
-    mirrored = cashctrl_ledger.ledger().reset_index(drop=True)
+    mirrored = cashctrl.ledger()
     assert txn_to_str(mirrored) == txn_to_str(expected)
 
-    # Mirror with delete=False
+    # Mirror existing transactions with delete=False has no impact
     target = ledger_entries.iloc[[0, 1, 2]]
-    cashctrl_ledger.mirror_ledger(target=target, delete=False)
-    mirrored = cashctrl_ledger.ledger().reset_index(drop=True)
-    expected = StandaloneLedger.standardize_ledger(target)
+    cashctrl.mirror_ledger(target=target, delete=False)
+    mirrored = cashctrl.ledger()
     assert txn_to_str(mirrored) == txn_to_str(expected)
 
     # Mirror with delete=True
     target = ledger_entries.iloc[[0, 1, 2]]
-    cashctrl_ledger.mirror_ledger(target=target)
-    mirrored = cashctrl_ledger.ledger().reset_index(drop=True)
+    cashctrl.mirror_ledger(target=target)
+    mirrored = cashctrl.ledger()
     expected = StandaloneLedger.standardize_ledger(target)
     assert txn_to_str(mirrored) == txn_to_str(expected)
 
     # Mirror an empty target state
-    cashctrl_ledger.mirror_ledger(target=pd.DataFrame({}), delete=True)
-    assert cashctrl_ledger.ledger().empty
+    cashctrl.mirror_ledger(target=pd.DataFrame({}), delete=True)
+    assert cashctrl.ledger().empty

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -1,3 +1,4 @@
+from io import StringIO
 from typing import List
 import pytest
 import pandas as pd
@@ -24,48 +25,18 @@ def add_vat_code():
     cashctrl.mirror_ledger(target=initial_ledger, delete=True)
     cashctrl.delete_vat_code(code="Test_VAT_code")
 
-individual_transaction = pd.DataFrame({
-    'id': ['1'],
-    'date': ['2024-05-24'],
-    'account': [2270],
-    'counter_account': [2210],
-    'amount': [100],
-    'currency': ['USD'],
-    'text': ['pytest added ledger112'],
-    'vat_code': ['Test_VAT_code'],
-    'document': ['/file1.txt'],
-})
-collective_transaction = pd.DataFrame({
-    'id': ['2', '2'],
-    'date': ['2024-05-24', '2024-05-24'],
-    'account': [2210, 2270],
-    'amount': [-100, 100],
-    'currency': ['USD', 'USD'],
-    'text': ['pytest added ledger111', 'pytest added ledger222'],
-    'vat_code': ['Test_VAT_code', 'Test_VAT_code'],
-    'document': ['/subdir/file2.txt', '/subdir/file2.txt'],
-})
-alt_collective_transaction = pd.DataFrame({
-    'id': ['3', '3'],
-    'date': ['2024-04-24', '2024-04-24'],
-    'account': [2210, 2270],
-    'amount': [-200, 200],
-    'currency': ['USD', 'USD'],
-    'text': ['pytest added alt ledger 1', 'pytest added alt ledger 2'],
-    'vat_code': ['Test_VAT_code', 'Test_VAT_code'],
-    'document': ['document-col-alt.pdf', 'document-col-alt.pdf'],
-})
-alt_individual_transaction = pd.DataFrame({
-    'id': ['4'],
-    'date': ['2024-04-24'],
-    'account': [2270],
-    'counter_account': [2210],
-    'amount': [500],
-    'currency': ['USD'],
-    'text': ['pytest added alt single ledger'],
-    'vat_code': ['Test_VAT_code'],
-    'document': ['document-alt.pdf'],
-})
+@pytest.fixture
+def ledger_entries():
+    LEDGER_CSV = """
+        id, date,    account, counter_account, currency, amount,      vat_code, text,                             document
+         1, 2024-05-24, 2270,            2210,      CHF,    100, Test_VAT_code, pytest single transaction 1,      /file1.txt
+         2, 2024-05-24, 2210,                ,      USD,   -100, Test_VAT_code, pytest collective txn 1 - line 1, /subdir/file2.txt
+         2, 2024-05-24, 2270,                ,      USD,    100, Test_VAT_code, pytest collective txn 1 - line 2, /subdir/file2.txt
+         3, 2024-04-24, 2210,                ,      USD,   -200, Test_VAT_code, pytest collective txn 2 - line 1, /document-col-alt.pdf
+         3, 2024-04-24, 2270,                ,      USD,    200, Test_VAT_code, pytest collective txn 2 - line 2, /document-col-alt.pdf
+         4, 2024-05-24, 2270,            2210,      CHF,    100, Test_VAT_code, pytest single transaction 2,      /document-alt.pdf
+    """
+    return pd.read_csv(StringIO(LEDGER_CSV), skipinitialspace=True)
 
 def txn_to_str(df: pd.DataFrame) -> List[str]:
     df = nest(df, columns=[col for col in df.columns if not col in ['id', 'date']], key='txn')
@@ -73,16 +44,17 @@ def txn_to_str(df: pd.DataFrame) -> List[str]:
     result = [f'{str(date)},{df_to_consistent_str(txn)}' for date, txn in zip(df['date'], df['txn'])]
     return result.sort()
 
-def test_ledger_accessor_mutators_single_transaction(add_vat_code):
+def test_ledger_accessor_mutators_single_transaction(add_vat_code, ledger_entries):
     cashctrl_ledger = CashCtrlLedger()
 
     # Test adding a ledger entry
+    target = ledger_entries.iloc[[0]]
     initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    cashctrl_ledger.add_ledger_entry(entry=individual_transaction)
+    cashctrl_ledger.add_ledger_entry(target)
     updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
     outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
     created = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
-    expected = StandaloneLedger.standardize_ledger(individual_transaction)
+    expected = StandaloneLedger.standardize_ledger(target)
     pd.testing.assert_frame_equal(created.drop(columns=['id']), expected.drop(columns=['id']))
 
     # Test delete the created ledger entry
@@ -92,7 +64,7 @@ def test_ledger_accessor_mutators_single_transaction(add_vat_code):
 
     # Test adding a ledger entry without VAT code
     initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    new_entry = individual_transaction.copy()
+    new_entry = ledger_entries.iloc[[0]].copy()
     new_entry['vat_code'] = None
     new_entry['text'] = 'Ledger entry without VAT'
     cashctrl_ledger.add_ledger_entry(entry=new_entry)
@@ -104,7 +76,7 @@ def test_ledger_accessor_mutators_single_transaction(add_vat_code):
 
     # Test update a ledger entry
     initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    new_entry = individual_transaction.copy()
+    new_entry = ledger_entries.iloc[[0]].copy()
     new_entry['amount'].iat[0] = 300
     new_entry['id'] = created['id'].iat[0]
     cashctrl_ledger.update_ledger_entry(entry=new_entry)
@@ -122,31 +94,32 @@ def test_ledger_accessor_mutators_single_transaction(add_vat_code):
 
     # Test replace with an collective ledger entry
     initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    new_entry = collective_transaction.copy()
+    new_entry = ledger_entries.iloc[[1, 2]].copy()
     new_entry['id'] = created['id'].iat[0]
     cashctrl_ledger.update_ledger_entry(entry=new_entry)
     updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
     outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
     updated = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
     expected = StandaloneLedger.standardize_ledger(new_entry)
-    pd.testing.assert_frame_equal(updated, expected)
+    pd.testing.assert_frame_equal(updated.drop(columns=['id']).reset_index(drop=True), expected.drop(columns=['id']).reset_index(drop=True), check_column_type=False)
 
     # Test delete the updated ledger entry
     cashctrl_ledger.delete_ledger_entry(ids=created['id'].iat[0])
     ledger = cashctrl_ledger.ledger().reset_index(drop=True)
     assert created['id'].iat[0] not in ledger['id']
 
-def test_ledger_accessor_mutators_collective_transaction(add_vat_code):
+def test_ledger_accessor_mutators_collective_transaction(add_vat_code, ledger_entries):
     cashctrl_ledger = CashCtrlLedger()
 
     # Test adding a ledger entry
     initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    cashctrl_ledger.add_ledger_entry(entry=collective_transaction)
+    target = ledger_entries.iloc[[1, 2]]
+    cashctrl_ledger.add_ledger_entry(target)
     updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
     outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
     created = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
-    expected = StandaloneLedger.standardize_ledger(collective_transaction)
-    pd.testing.assert_frame_equal(created.drop(columns=['id']), expected.drop(columns=['id']))
+    expected = StandaloneLedger.standardize_ledger(target)
+    pd.testing.assert_frame_equal(created.drop(columns=['id']).reset_index(drop=True), expected.drop(columns=['id']).reset_index(drop=True))
 
     # Test delete the created ledger entry
     cashctrl_ledger.delete_ledger_entry(ids=created['id'].iat[0])
@@ -155,18 +128,18 @@ def test_ledger_accessor_mutators_collective_transaction(add_vat_code):
 
     # Test adding a ledger entry without VAT
     initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    new_entry = collective_transaction.copy()
+    new_entry = ledger_entries.iloc[[1, 2]].copy()
     new_entry['vat_code'] = None
     cashctrl_ledger.add_ledger_entry(entry=new_entry)
     updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
     outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
     created = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
     expected = StandaloneLedger.standardize_ledger(new_entry)
-    pd.testing.assert_frame_equal(created.drop(columns=['id']), expected.drop(columns=['id']))
+    pd.testing.assert_frame_equal(created.drop(columns=['id']).reset_index(drop=True), expected.drop(columns=['id']).reset_index(drop=True))
 
     # Test update a ledger entry
     initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    new_entry = collective_transaction.copy()
+    new_entry = ledger_entries.iloc[[1, 2]].copy()
     new_entry['amount'].iat[0] = 300
     new_entry['amount'].iat[1] = -300
     new_entry['id'] = created['id'].iat[0]
@@ -175,11 +148,11 @@ def test_ledger_accessor_mutators_collective_transaction(add_vat_code):
     outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
     updated = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
     expected = StandaloneLedger.standardize_ledger(new_entry)
-    pd.testing.assert_frame_equal(updated, expected)
+    pd.testing.assert_frame_equal(updated.reset_index(drop=True), expected.reset_index(drop=True))
 
     # Test replace with an individual ledger entry
     initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    new_entry = individual_transaction.copy()
+    new_entry = ledger_entries.iloc[[0]].copy()
     new_entry['id'] = created['id'].iat[0]
     new_entry['vat_code'] = None
     cashctrl_ledger.update_ledger_entry(entry=new_entry)
@@ -187,7 +160,7 @@ def test_ledger_accessor_mutators_collective_transaction(add_vat_code):
     outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
     updated = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
     expected = StandaloneLedger.standardize_ledger(new_entry)
-    pd.testing.assert_frame_equal(updated, expected)
+    pd.testing.assert_frame_equal(updated.reset_index(drop=True), expected.reset_index(drop=True))
 
     # Test delete the updated ledger entry
     cashctrl_ledger.delete_ledger_entry(ids=created['id'].iat[0])
@@ -195,53 +168,53 @@ def test_ledger_accessor_mutators_collective_transaction(add_vat_code):
     assert created['id'].iat[0] not in ledger['id']
 
 # Tests for addition logic edge cases
-def test_add_ledger_with_non_existent_vat():
+def test_add_ledger_with_non_existent_vat(ledger_entries):
     cashctrl_ledger = CashCtrlLedger()
 
     # Adding a ledger with non existent VAT code should raise an error
-    entry = individual_transaction.copy()
+    entry = ledger_entries.iloc[[0]].copy()
     entry['vat_code'].iat[0] = 'Test_Non_Existent_VAT_code'
     with pytest.raises(ValueError, match='No id found for tax code'):
         cashctrl_ledger.add_ledger_entry(entry=entry)
 
     # Adding a ledger with non existent account code should raise an error
-    entry = individual_transaction.copy()
+    entry = ledger_entries.iloc[[0]].copy()
     entry['account'].iat[0] = 33333
     with pytest.raises(ValueError, match='No id found for account'):
         cashctrl_ledger.add_ledger_entry(entry=entry)
 
     # Adding a ledger with non existent currency code should raise an error
-    entry = individual_transaction.copy()
+    entry = ledger_entries.iloc[[0]].copy()
     entry['currency'].iat[0] = 'Non_Existent_Currency'
     with pytest.raises(ValueError, match='No id found for currency'):
         cashctrl_ledger.add_ledger_entry(entry=entry)
 
 # Tests for updating logic edge cases
-def test_update_ledger_with_edge_cases(add_vat_code):
+def test_update_ledger_with_edge_cases(add_vat_code, ledger_entries):
     cashctrl_ledger = CashCtrlLedger()
 
     initial_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
-    cashctrl_ledger.add_ledger_entry(entry=individual_transaction)
+    cashctrl_ledger.add_ledger_entry(ledger_entries.iloc[[0]])
     updated_ledger = cashctrl_ledger.ledger().reset_index(drop=True)
     outer_join = pd.merge(initial_ledger, updated_ledger, how='outer', indicator=True)
     created = outer_join[outer_join['_merge'] == "right_only"].drop('_merge', axis = 1).reset_index(drop=True)
 
     # Updating a ledger with non existent VAT code should raise an error
-    new_entry = individual_transaction.copy()
+    new_entry = ledger_entries.iloc[[0]].copy()
     new_entry['id'] = created['id'].iat[0]
     new_entry['vat_code'].iat[0] = 'Test_Non_Existent_VAT_code'
     with pytest.raises(ValueError, match='No id found for tax code'):
         cashctrl_ledger.update_ledger_entry(entry=new_entry)
 
     # Updating a ledger with non existent account code should raise an error
-    new_entry = individual_transaction.copy()
+    new_entry = ledger_entries.iloc[[0]].copy()
     new_entry['id'] = created['id'].iat[0]
     new_entry['account'].iat[0] = 333333
     with pytest.raises(ValueError, match='No id found for account'):
         cashctrl_ledger.update_ledger_entry(entry=new_entry)
 
     # Updating a ledger with non existent currency code should raise an error
-    new_entry = individual_transaction.copy()
+    new_entry = ledger_entries.iloc[[0]].copy()
     new_entry['id'] = created['id'].iat[0]
     new_entry['currency'].iat[0] = 'CURRENCY'
     with pytest.raises(ValueError, match='No id found for currency'):
@@ -253,10 +226,10 @@ def test_update_ledger_with_edge_cases(add_vat_code):
     assert created['id'].iat[0] not in ledger['id']
 
 # Updating a non-existent ledger should raise an error
-def test_update_non_existent_ledger():
+def test_update_non_existent_ledger(ledger_entries):
     cashctrl_ledger = CashCtrlLedger()
-    entry = individual_transaction.copy()
-    entry['id'].iat[0] = 999999
+    entry = ledger_entries.iloc[[0]].copy()
+    entry['id'] = 999999
     with pytest.raises(RequestException):
         cashctrl_ledger.update_ledger_entry(entry=entry)
 
@@ -266,49 +239,51 @@ def test_delete_non_existent_ledger():
     with pytest.raises(RequestException):
         cashctrl_ledger.delete_ledger_entry(ids='non-existent')
 
-def test_mirror_ledger(add_vat_code):
+def test_mirror_ledger(add_vat_code, ledger_entries):
     cashctrl_ledger = CashCtrlLedger()
 
     # Mirror with one single and one collective transaction
-    target = pd.concat([individual_transaction, collective_transaction])
+    target = ledger_entries.iloc[[0, 1, 2]].copy()
     cashctrl_ledger.mirror_ledger(target=target)
     mirrored = cashctrl_ledger.ledger()
     assert txn_to_str(target) == txn_to_str(mirrored)
 
     # Mirror with duplicate transactions and delete=False
-    new_individual_transaction = individual_transaction.copy()
-    new_collective_transaction = collective_transaction.copy()
-    new_individual_transaction['id'].iat[0] = 5
-    new_collective_transaction['id'].iat[0] = 6
-    new_collective_transaction['id'].iat[1] = 6
+    new_individual_transaction = ledger_entries.iloc[[0]].copy()
+    new_collective_transaction = ledger_entries.iloc[[1, 2]].copy()
+    new_individual_transaction['id'] = 5
+    new_collective_transaction['id'] = 6
     target = pd.concat([
-        individual_transaction,
+        ledger_entries.iloc[[0]],
         new_individual_transaction,
-        collective_transaction,
+        ledger_entries.iloc[[1, 2]],
         new_collective_transaction,
     ])
     cashctrl_ledger.mirror_ledger(target=target)
     mirrored = cashctrl_ledger.ledger().reset_index(drop=True)
-    assert txn_to_str(target) == txn_to_str(mirrored)
+    expected = StandaloneLedger.standardize_ledger(target)
+    assert txn_to_str(mirrored) == txn_to_str(expected)
 
     # Mirror with alternative transactions and delete=False
-    target = pd.concat([alt_individual_transaction, alt_collective_transaction])
-    expected = pd.concat([mirrored, target])
+    target = ledger_entries.iloc[[5, 3, 4]]
+    expected = pd.concat([mirrored, StandaloneLedger.standardize_ledger(target)])
     cashctrl_ledger.mirror_ledger(target=target, delete=False)
     mirrored = cashctrl_ledger.ledger().reset_index(drop=True)
     assert txn_to_str(mirrored) == txn_to_str(expected)
 
     # Mirror with delete=False
-    target = pd.concat([individual_transaction, collective_transaction])
+    target = ledger_entries.iloc[[0, 1, 2]]
     cashctrl_ledger.mirror_ledger(target=target, delete=False)
     mirrored = cashctrl_ledger.ledger().reset_index(drop=True)
-    assert txn_to_str(target) == txn_to_str(mirrored)
+    expected = StandaloneLedger.standardize_ledger(target)
+    assert txn_to_str(mirrored) == txn_to_str(expected)
 
     # Mirror with delete=True
-    target = pd.concat([individual_transaction, collective_transaction])
+    target = ledger_entries.iloc[[0, 1, 2]]
     cashctrl_ledger.mirror_ledger(target=target)
     mirrored = cashctrl_ledger.ledger().reset_index(drop=True)
-    assert txn_to_str(target) == txn_to_str(mirrored)
+    expected = StandaloneLedger.standardize_ledger(target)
+    assert txn_to_str(mirrored) == txn_to_str(expected)
 
     # Mirror an empty target state
     cashctrl_ledger.mirror_ledger(target=pd.DataFrame({}), delete=True)

--- a/tests/test_ledger_attachmanets.py
+++ b/tests/test_ledger_attachmanets.py
@@ -1,0 +1,75 @@
+from typing import List
+import pytest
+import pandas as pd
+from cashctrl_ledger import CashCtrlLedger
+
+@pytest.fixture(scope="module")
+def tmp_path_for_module(tmp_path_factory):
+    return tmp_path_factory.mktemp("temp")
+
+@pytest.fixture(scope="module")
+def mock_directory(tmp_path_for_module):
+    """Create a temporary directory, populate with files and folders."""
+    tmp_path = tmp_path_for_module
+    (tmp_path / 'file1.txt').write_text("This is a text file.")
+    subdir = tmp_path / 'subdir'
+    subdir.mkdir(exist_ok=True)
+    (subdir / 'file2.txt').write_text("A Text file in a subdirectory.")
+    return tmp_path
+
+@pytest.fixture(scope="module")
+def files(mock_directory):
+    """Create a CachedCashCtrlClient, populate with files and folders."""
+    cc_client = CashCtrlLedger()
+    initial_files = cc_client._client.list_files()
+    cc_client._client.mirror_directory(mock_directory, delete_files=False)
+    updated_files = cc_client._client.list_files()
+    created_ids = set(updated_files['id']).difference(initial_files['id'])
+
+    # return created files
+    yield updated_files[updated_files['id'].isin(created_ids)]
+
+    # Delete files added in the test
+    params = { 'ids': ','.join(str(i) for i in created_ids), 'force': True }
+    cc_client._client.post("file/delete.json", params=params)
+
+@pytest.fixture(scope="module")
+def ledger_ids():
+    """Populate remote ledger with three new entries and return their ids in a list."""
+    entry = pd.DataFrame({
+        'date': ['2024-05-24'],
+        'account': [2270],
+        'counter_account': [2210],
+        'amount': [100],
+        'currency': ['CHF'],
+        'text': ['test entry'],
+    })
+    engine = CashCtrlLedger()
+    ledger_ids = [engine.add_ledger_entry(entry) for _ in range(3)]
+
+    yield ledger_ids
+
+    # Restore original ledger state
+    engine.delete_ledger_entry(list(map(str, ledger_ids)))
+
+def test_get_ledger_attachments(files, ledger_ids):
+    def sort_dict_values(items):
+        return {key: value.sort() for key, value in items.items()}
+    engine = CashCtrlLedger()
+    initial = engine._get_ledger_attachments()
+
+    engine._client.post("journal/update_attachments.json", data={'id': ledger_ids[0], 'fileIds': files['id'].iat[0]})
+    engine._client.invalidate_journal_cache()
+    expected = initial | {ledger_ids[0]: ['/file1.txt']}
+    assert engine._get_ledger_attachments() == expected
+
+    engine._client.post("journal/update_attachments.json", data={'id': ledger_ids[1], 'fileIds': files['id'].iat[1]})
+    engine._client.invalidate_journal_cache()
+    expected = initial | {ledger_ids[0]: ['/file1.txt'], ledger_ids[1]: ['/subdir/file2.txt']}
+    assert engine._get_ledger_attachments() == expected
+
+    file_ids = f'{files['id'].iat[0]},{files['id'].iat[1]}'
+    engine._client.post("journal/update_attachments.json", data={'id': ledger_ids[1], 'fileIds': file_ids})
+    engine._client.invalidate_journal_cache()
+    expected = initial | {ledger_ids[0]: ['/file1.txt'], ledger_ids[1]:  ['/file1.txt', '/subdir/file2.txt']}
+    assert sort_dict_values(engine._get_ledger_attachments()) == sort_dict_values(expected)

--- a/tests/test_ledger_attachmanets.py
+++ b/tests/test_ledger_attachmanets.py
@@ -1,3 +1,7 @@
+"""
+Unit tests for listing, attaching and detaching remote files.
+"""
+
 from typing import List
 import pytest
 import pandas as pd

--- a/tests/test_testing.py
+++ b/tests/test_testing.py
@@ -1,0 +1,48 @@
+"""
+Unit tests for functions that help in testing.
+"""
+
+import pytest
+import pandas as pd
+from cashctrl_ledger import assert_frame_equal
+
+def test_assert_frame_equal_basic_equality():
+    df1 = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
+    df2 = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
+    assert_frame_equal(df1, df2)
+
+def test_assert_frame_equal_different_indices():
+    df1 = pd.DataFrame({'A': [1, 2, 3]}, index=[0, 1, 2])
+    df2 = pd.DataFrame({'A': [1, 2, 3]}, index=[3, 4, 5])
+    with pytest.raises(AssertionError):
+        assert_frame_equal(df1, df2)
+    assert_frame_equal(df1, df2, ignore_index=True)
+
+def test_assert_frame_equal_ignore_columns():
+    df1 = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6], 'C': [7, 8, 9]})
+    df2 = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6], 'C': [10, 11, 12]})
+    assert_frame_equal(df1, df2, ignore_columns=['C'])
+
+def test_assert_frame_equal_ignore_columns_with_inequality():
+    df1 = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6], 'C': [7, 8, 9]})
+    df2 = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6], 'C': [10, 11, 12]})
+    with pytest.raises(AssertionError):
+        assert_frame_equal(df1, df2)
+    assert_frame_equal(df1, df2, ignore_columns=['C'])
+
+def test_assert_frame_equal_inequality():
+    df1 = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
+    df2 = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 7]})
+    with pytest.raises(AssertionError):
+        assert_frame_equal(df1, df2)
+
+def test_assert_frame_equal_empty_dataframes():
+    df1 = pd.DataFrame()
+    df2 = pd.DataFrame()
+    assert_frame_equal(df1, df2)
+
+def test_assert_frame_equal_different_shapes():
+    df1 = pd.DataFrame({'A': [1, 2, 3]})
+    df2 = pd.DataFrame({'A': [1, 2, 3], 'B': [4, 5, 6]})
+    with pytest.raises(AssertionError):
+        assert_frame_equal(df1, df2)


### PR DESCRIPTION
This PR is pure re-factoring. It does not change the functionality, but streamlines the code base such that new features and tests can be added with fewer code changes.

Change:
1. Extract method to map ledger entry (extracts duplicated code from add_ledger_entry in update_ledger_entry into a local function)
2. Streamline tests (clarify fixtures, define test data in a table, split long test functions into smaller steps, simplify checks)

The PR is best reviewed commit-by-commit.