### PR TITLE
Map Ledger Entries with Foreign Currency Amounts to CashCtrl

### DIFF
--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -287,6 +287,13 @@ class CashCtrlLedger(LedgerEngine):
             return df
         remote = process_ledger(self.ledger())
         target = self.sanitize_ledger(self.standardize_ledger(target))
+        replace_amount = target['base_currency_amount'].isna() & (target['currency'] == self.base_currency())
+        if replace_amount.any():
+            target['base_currency_amount'] = np.where(replace_amount, target['amount'],
+                                                      target['base_currency_amount'])
+        if target['document'].isna().any():
+            target['document'] = target.groupby('id')['document'].ffill()
+            target['document'] = target.groupby('id')['document'].bfill()
         target['date'] = target['date'].ffill()
         target = process_ledger(target)
         if target['id'].duplicated().any():

--- a/tests/test_collective_entry_currency_rate.py
+++ b/tests/test_collective_entry_currency_rate.py
@@ -1,0 +1,91 @@
+"""
+Unit tests for CashCtrlLedger._collective_transaction_currency_and_rate().
+
+Test helper function to map collective transactions in foreign currencies
+from pyledger to CashCtrl format.
+"""
+
+import pytest
+import pandas as pd
+from cashctrl_ledger import CashCtrlLedger
+
+def test_collective_entry_currency_and_rate_without_currency():
+    cashctrl = CashCtrlLedger()
+    df = pd.DataFrame({
+        'currency': [None, None, None],
+        'amount': [100, -200, 100],
+        'base_currency_amount': [100, -200, 100]
+    })
+    result = cashctrl._collective_transaction_currency_and_rate(df)
+    assert result == ("CHF", 1.0)
+
+def test_collective_entry_currency_and_rate_in_base_currency():
+    cashctrl = CashCtrlLedger()
+    df = pd.DataFrame({
+        'currency': ["CHF", "CHF", "CHF"],
+        'amount': [-100, 200, -100],
+        'base_currency_amount': [-100, 200, -100]
+    })
+    result = cashctrl._collective_transaction_currency_and_rate(df)
+    assert result == ("CHF", 1.0)
+
+def test_collective_entry_currency_and_rate_in_single_foreign_currency():
+    cashctrl = CashCtrlLedger()
+    df = pd.DataFrame({
+        'currency': ["EUR", "EUR", "EUR"],
+        'amount': [100, -200, 100],
+        'base_currency_amount': [120, -240, 120]
+    })
+    result = cashctrl._collective_transaction_currency_and_rate(df)
+    assert result == ("EUR", 1.2)
+
+def test_collective_entry_currency_and_rate_in_base_and_foreign_currency():
+    cashctrl = CashCtrlLedger()
+    df = pd.DataFrame({
+        'currency': ["EUR", "GBP", "EUR"],
+        'amount': [100, -200, 100],
+        'base_currency_amount': [120, -240, 120]
+    })
+    err_msg = "CashCtrl allows only the base currency plus a single foreign currency in a collective booking."
+    with pytest.raises(ValueError, match=err_msg):
+        cashctrl._collective_transaction_currency_and_rate(df)
+
+def test_collective_entry_currency_and_rate_multiple_foreign_currencies():
+    cashctrl = CashCtrlLedger()
+    df = pd.DataFrame({
+        'currency': ["EUR", "CHF", "EUR"],
+        'amount': [150, -200, 50],
+        'base_currency_amount': [138, -200, 46]
+    })
+    result = cashctrl._collective_transaction_currency_and_rate(df)
+    assert result == ("EUR", 0.92)
+
+def test_collective_entry_currency_and_rate_incoherent_exchange_rate():
+    cashctrl = CashCtrlLedger()
+    df = pd.DataFrame({
+        'currency': ["EUR", "CHF", "EUR"],
+        'amount': [150, -200, 50],
+        'base_currency_amount': [138, -200, 47]
+    })
+    with pytest.raises(ValueError, match="Incoherent FX rates in collective booking."):
+        cashctrl._collective_transaction_currency_and_rate(df)
+
+def test_collective_entry_currency_and_rate_precise_rate_calculation():
+    cashctrl = CashCtrlLedger()
+    df = pd.DataFrame({
+        'currency': ["EUR", "EUR", "CHF"],
+        'amount': [100, 1, -101],
+        'base_currency_amount': [91.44, 0.91, -101]
+    })
+    result = cashctrl._collective_transaction_currency_and_rate(df)
+    assert result == ("EUR", 0.9144)
+
+def test_collective_entry_currency_and_rate_incoherent_exchange_rate():
+    cashctrl = CashCtrlLedger()
+    df = pd.DataFrame({
+        'currency': ["EUR", "EUR", "CHF"],
+        'amount': [100, 1, -101],
+        'base_currency_amount': [91.51, 0.91, -101]
+    })
+    with pytest.raises(ValueError, match="Incoherent FX rates in collective booking."):
+        cashctrl._collective_transaction_currency_and_rate(df)

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -28,14 +28,14 @@ VAT_CSV = """
 """
 
 LEDGER_CSV = """
-    id,    date, account, counter_account, currency, amount,      vat_code, text,                             document
-    1, 2024-05-24, 10023,           19993,      CHF,    100, Test_VAT_code, pytest single transaction 1,      /file1.txt
-    2, 2024-05-24, 10022,                ,      USD,   -100, Test_VAT_code, pytest collective txn 1 - line 1, /subdir/file2.txt
-    2, 2024-05-24, 10022,                ,      USD,      1, Test_VAT_code, pytest collective txn 1 - line 1, /subdir/file2.txt
-    2, 2024-05-24, 10022,                ,      USD,     99, Test_VAT_code, pytest collective txn 1 - line 1, /subdir/file2.txt
-    3, 2024-04-24, 10021,                ,      EUR,   -200, Test_VAT_code, pytest collective txn 2 - line 1, /document-col-alt.pdf
-    3, 2024-04-24, 10021,                ,      EUR,    200, Test_VAT_code, pytest collective txn 2 - line 2, /document-col-alt.pdf
-    4, 2024-05-24, 10022,           19992,      USD,    300, Test_VAT_code, pytest single transaction 2,      /document-alt.pdf
+    id,    date, account, counter_account, currency, amount, base_currency_amount,      vat_code, text,                             document
+    1, 2024-05-24, 10023,           19993,      CHF,    100,               100.00, Test_VAT_code, pytest single transaction 1,      /file1.txt
+    2, 2024-05-24, 10022,                ,      USD,   -100,               -88.88, Test_VAT_code, pytest collective txn 1 - line 1, /subdir/file2.txt
+    2, 2024-05-24, 10022,                ,      USD,      1,                 0.89, Test_VAT_code, pytest collective txn 1 - line 1, /subdir/file2.txt
+    2, 2024-05-24, 10022,                ,      USD,     99,                87.99, Test_VAT_code, pytest collective txn 1 - line 1, /subdir/file2.txt
+    3, 2024-04-24, 10021,                ,      EUR,   -200,              -175.55, Test_VAT_code, pytest collective txn 2 - line 1, /document-col-alt.pdf
+    3, 2024-04-24, 10021,                ,      EUR,    200,               175.55, Test_VAT_code, pytest collective txn 2 - line 2, /document-col-alt.pdf
+    4, 2024-05-24, 10022,           19992,      USD,    300,               450.45, Test_VAT_code, pytest single transaction 2,      /document-alt.pdf
 """
 
 LEDGER_ENTRIES = pd.read_csv(StringIO(LEDGER_CSV), skipinitialspace=True)


### PR DESCRIPTION
This pull request maps edger entries with amounts denominated in a currency different from the accounting system's base currency to CashCtrl.

CashCtrl handles foreign currency amounts differently than the pyledger data structure, which is based on best accounting practices. CashCtrl does not store the foreign currency amount directly but allows specifying an exchange rate to convert foreign currency amounts to the base currency. The exchange rate is set at the transaction level, meaning items in collective transactions in CashCtrl can be denominated in either the base currency or one additional foreign currency.

This pull request ensures proper mapping of foreign currency amounts between standard pyledger and CashCtrl, raising errors when ledger data does not conform to CashCtrl's restrictions.