### PR TITLE
Debug Ledger mirroring

### DIFF
--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -363,6 +363,13 @@ class CashCtrlLedger(LedgerEngine):
                     except Exception as e:
                         raise Exception(f"Error while adding ledger entry {id}: {e}") from e
 
+        # return number of elements found, targeted, changed:
+        stats = {'pre-existing': int(count['remote'].sum()),
+                 'targeted': int(count['target'].sum()),
+                 'added': count['n_add'].sum(),
+                 'deleted': count['n_delete'].sum() if delete else 0}
+        return stats
+
     def _get_ledger_attachments(self) -> Dict[str, List[str]]:
         """
         Retrieves paths of files attached to CashCtrl ledger entries

--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -620,7 +620,7 @@ class CashCtrlLedger(LedgerEngine):
                 items.append({
                     'accountId': self._client.account_to_id(row['account']),
                     'debit': -amount if amount < 0 else None,
-                    'credit': amount if amount > 0 else None,
+                    'credit': amount if amount >= 0 else None,
                     'taxId': None if pd.isna(row['vat_code']) else self._client.tax_code_to_id(row['vat_code']),
                     'description': row['text'],
                 })

--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -288,6 +288,17 @@ class CashCtrlLedger(LedgerEngine):
         # transaction.
         df['document'] = df.groupby('id')['document'].ffill()
         df['document'] = df.groupby('id')['document'].bfill()
+
+        # TODO: move this code block to parent class
+        # Swap account and counter_account if a counter_account but no account is provided
+        swap_accounts = df['account'].isna() & df['counter_account'].notna()
+        if swap_accounts.any():
+            df.loc[swap_accounts, 'account'] = df.loc[swap_accounts, 'counter_account']
+            df.loc[swap_accounts, 'counter_account'] = pd.NA
+            df.loc[swap_accounts, 'amount'] = -1 * df.loc[swap_accounts, 'amount']
+            df.loc[swap_accounts, 'base_currency_amount'] = (
+                -1 * df.loc[swap_accounts, 'base_currency_amount'])
+
         return df
 
     def mirror_ledger(self, target: pd.DataFrame, delete: bool = True):

--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -595,7 +595,9 @@ class CashCtrlLedger(LedgerEngine):
                 if row['currency'] == currency:
                     amount = row['amount']
                 elif row['currency'] == base_currency:
-                    amount = row['amount'] / fx_rate
+                    # TODO: Once precision() is implemented, use `round_to_precision()`
+                    # instead of hard-coded rounding
+                    amount = round(row['amount'] / fx_rate, 2)
                 else:
                     raise ValueError("Currencies oder than base or transaction currency "
                                      "are not allowed in CashCtrl collective transactions.")

--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -297,8 +297,8 @@ class CashCtrlLedger(LedgerEngine):
             new = df.loc[items_to_split].copy()
             new['account'] = new['counter_account']
             new.loc[:, 'counter_account'] = pd.NA
-            new['amount'] = -1 * new['amount']
-            new['base_currency_amount'] = -1 * new['base_currency_amount']
+            for col in ['amount', 'base_currency_amount']:
+                new[col] = np.where(new[col].isna() | (new[col] == 0), new[col], -1 * new[col])
             df.loc[items_to_split, 'counter_account'] = pd.NA
             df = pd.concat([df, new])
 

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -231,7 +231,7 @@ def test_ledger_accessor_mutators_another_fx_transaction(set_up_vat_and_account)
     id = cashctrl.add_ledger_entry(target)
     remote = cashctrl.ledger()
     created = remote.loc[remote['id'] == str(id)]
-    expected = cashctrl.standardize_ledger_entries(target)
+    expected = cashctrl.standardize_ledger(target)
     assert_frame_equal(created, expected, ignore_index=True, ignore_columns=['id'])
 
 def test_add_ledger_with_non_existing_vat():

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -50,6 +50,8 @@ LEDGER_CSV = """
     11, 2024-05-24, 10023,                ,      CHF,     100.00,                     , Test_VAT_code, Collective transaction with zero amount,
     11, 2024-05-24, 19993,                ,      CHF,    -100.00,                     ,              , Collective transaction with zero amount,
     11, 2024-05-24, 19993,                ,      CHF,       0.00,                     ,              , Collective transaction with zero amount,
+    12, 2024-03-02,      ,           19991,      EUR,  600000.00,            599580.00,              , Convert 600k EUR to CHF @ 0.9993,
+    12, 2024-03-02, 19993,                ,      CHF,  599580.00,            599580.00,              , Convert 600k EUR to CHF @ 0.9993,
 """
 LEDGER_ENTRIES = pd.read_csv(StringIO(LEDGER_CSV), skipinitialspace=True)
 TEST_ACCOUNTS = pd.read_csv(StringIO(ACCOUNT_CSV), skipinitialspace=True)
@@ -274,6 +276,15 @@ def test_ledger_accessor_mutators_leg_with_zero_amount(set_up_vat_and_account):
     # Collective transaction with leg of zero base currency
     cashctrl = CashCtrlLedger()
     target = LEDGER_ENTRIES.query('id == 11')
+    id = cashctrl.add_ledger_entry(target)
+    remote = cashctrl.ledger()
+    created = remote.loc[remote['id'] == str(id)]
+    expected = cashctrl.standardize_ledger(target)
+    assert_frame_equal(created, expected, ignore_index=True, ignore_columns=['id'])
+
+def test_adding_large_fx_conversion(set_up_vat_and_account):
+    cashctrl = CashCtrlLedger()
+    target = LEDGER_ENTRIES.query('id == 12')
     id = cashctrl.add_ledger_entry(target)
     remote = cashctrl.ledger()
     created = remote.loc[remote['id'] == str(id)]

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -43,6 +43,9 @@ LEDGER_CSV = """
     7, 2024-01-16,      ,           19991,      EUR,  125000.00,            125362.50,              , Convert 125'000 EUR to CHF, /2024/banking/IB/2023-01.pdf
     7, 2024-01-16, 19993,                ,      CHF,  125362.50,            125362.50,              , Convert 125'000 EUR to CHF, /2024/banking/IB/2023-01.pdf
     8, 2024-05-24, 10021,           19991,      EUR,     -10.00,                -9.00,              , Individual transaction with negative amount,
+    9, 2024-05-24, 10023,           19993,      CHF,     100.00,                     ,              , Collective transaction - leg with debit and credit account,
+    9, 2024-05-24, 10021,                ,      EUR,      20.00,                19.00,              , Collective transaction - leg with credit account,
+    9, 2024-05-24,      ,           19991,      EUR,      20.00,                19.00,              , Collective transaction - leg with debit account,
 """
 
 LEDGER_ENTRIES = pd.read_csv(StringIO(LEDGER_CSV), skipinitialspace=True)
@@ -238,6 +241,16 @@ def test_ledger_accessor_mutators_another_fx_transaction(set_up_vat_and_account)
 def test_ledger_accessor_mutators_individual_transaction_negative_amount(set_up_vat_and_account):
     cashctrl = CashCtrlLedger()
     target = LEDGER_ENTRIES.query('id == 8')
+    id = cashctrl.add_ledger_entry(target)
+    remote = cashctrl.ledger()
+    created = remote.loc[remote['id'] == str(id)]
+    expected = cashctrl.standardize_ledger(target)
+    assert_frame_equal(created, expected, ignore_index=True, ignore_columns=['id'])
+
+def test_ledger_accessor_mutators_leg_with_credit_and_debit_account(set_up_vat_and_account):
+    # Collective transaction with credit and debit account in single line item
+    cashctrl = CashCtrlLedger()
+    target = LEDGER_ENTRIES.query('id == 9')
     id = cashctrl.add_ledger_entry(target)
     remote = cashctrl.ledger()
     created = remote.loc[remote['id'] == str(id)]

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -33,7 +33,7 @@ LEDGER_CSV = """
     2, 2024-05-24, 10022,                ,      USD,    -100.00,               -88.88, Test_VAT_code, pytest collective txn 1 - line 1, /subdir/file2.txt
     2, 2024-05-24, 10022,                ,      USD,       1.00,                 0.89, Test_VAT_code, pytest collective txn 1 - line 1, /subdir/file2.txt
     2, 2024-05-24, 10022,                ,      USD,      99.00,                87.99, Test_VAT_code, pytest collective txn 1 - line 1,
-    3, 2024-04-24, 10021,                ,      EUR,    -200.00,              -175.55, Test_VAT_code, pytest collective txn 2 - line 1, /document-col-alt.pdf
+    3, 2024-04-24,      ,           10021,      EUR,     200.00,               175.55, Test_VAT_code, pytest collective txn 2 - line 1, /document-col-alt.pdf
     3, 2024-04-24, 10021,                ,      EUR,     200.00,               175.55, Test_VAT_code, pytest collective txn 2 - line 2, /document-col-alt.pdf
     4, 2024-05-24, 10022,           19992,      USD,     300.00,               450.45, Test_VAT_code, pytest single transaction 2,      /document-alt.pdf
     5, 2024-04-04, 19993,                ,      CHF, -125000.00,           -125000.00,              , Convert -125'000 CHF to USD @ 1.10511,

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -42,6 +42,7 @@ LEDGER_CSV = """
     6, 2024-04-04, 19992,                ,      USD,  276277.50,            250000.00,              , Convert -250'000 CHF to USD @ 1.10511,
     7, 2024-01-16,      ,           19991,      EUR,  125000.00,            125362.50,              , Convert 125'000 EUR to CHF, /2024/banking/IB/2023-01.pdf
     7, 2024-01-16, 19993,                ,      CHF,  125362.50,            125362.50,              , Convert 125'000 EUR to CHF, /2024/banking/IB/2023-01.pdf
+    8, 2024-05-24, 10021,           19991,      EUR,     -10.00,                -9.00,              , Individual transaction with negative amount,
 """
 
 LEDGER_ENTRIES = pd.read_csv(StringIO(LEDGER_CSV), skipinitialspace=True)
@@ -228,6 +229,15 @@ def test_ledger_accessor_mutators_another_fx_transaction(set_up_vat_and_account)
     # Total debit (125 000.00) and total credit (125 000.00) must be equal.
     cashctrl = CashCtrlLedger()
     target = LEDGER_ENTRIES.query('id == 7')
+    id = cashctrl.add_ledger_entry(target)
+    remote = cashctrl.ledger()
+    created = remote.loc[remote['id'] == str(id)]
+    expected = cashctrl.standardize_ledger(target)
+    assert_frame_equal(created, expected, ignore_index=True, ignore_columns=['id'])
+
+def test_ledger_accessor_mutators_individual_transaction_negative_amount(set_up_vat_and_account):
+    cashctrl = CashCtrlLedger()
+    target = LEDGER_ENTRIES.query('id == 8')
     id = cashctrl.add_ledger_entry(target)
     remote = cashctrl.ledger()
     created = remote.loc[remote['id'] == str(id)]

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -40,6 +40,8 @@ LEDGER_CSV = """
     5, 2024-04-04, 19992,                ,      USD,  138138.75,            125000.00,              , Convert -125'000 CHF to USD @ 1.10511,
     6, 2024-04-04, 19993,                ,      CHF, -250000.00,                     ,              , Convert -250'000 CHF to USD @ 1.10511,
     6, 2024-04-04, 19992,                ,      USD,  276277.50,            250000.00,              , Convert -250'000 CHF to USD @ 1.10511,
+    7, 2024-01-16,      ,           19991,      EUR,  125000.00,            125362.50,              , Convert 125'000 EUR to CHF, /2024/banking/IB/2023-01.pdf
+    7, 2024-01-16, 19993,                ,      CHF,  125362.50,            125362.50,              , Convert 125'000 EUR to CHF, /2024/banking/IB/2023-01.pdf
 """
 
 LEDGER_ENTRIES = pd.read_csv(StringIO(LEDGER_CSV), skipinitialspace=True)
@@ -219,6 +221,17 @@ def test_ledger_accessor_mutators_fx_transaction_na_base_currency_amount(set_up_
     remote = cashctrl.ledger()
     created = remote.loc[remote['id'] == str(id)]
     expected = cashctrl.standardize_ledger(target)
+    assert_frame_equal(created, expected, ignore_index=True, ignore_columns=['id'])
+
+def test_ledger_accessor_mutators_another_fx_transaction(set_up_vat_and_account):
+    # This transaction raised RequestException on 2024-06-20: API call failed.
+    # Total debit (125 000.00) and total credit (125 000.00) must be equal.
+    cashctrl = CashCtrlLedger()
+    target = LEDGER_ENTRIES.query('id == 7')
+    id = cashctrl.add_ledger_entry(target)
+    remote = cashctrl.ledger()
+    created = remote.loc[remote['id'] == str(id)]
+    expected = cashctrl.standardize_ledger_entries(target)
     assert_frame_equal(created, expected, ignore_index=True, ignore_columns=['id'])
 
 def test_add_ledger_with_non_existing_vat():

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -28,26 +28,29 @@ VAT_CSV = """
 """
 
 LEDGER_CSV = """
-    id,    date, account, counter_account, currency,     amount, base_currency_amount,      vat_code, text,                             document
-    1, 2024-05-24, 10023,           19993,      CHF,     100.00,                     , Test_VAT_code, pytest single transaction 1,      /file1.txt
-    2, 2024-05-24, 10022,                ,      USD,    -100.00,               -88.88, Test_VAT_code, pytest collective txn 1 - line 1, /subdir/file2.txt
-    2, 2024-05-24, 10022,                ,      USD,       1.00,                 0.89, Test_VAT_code, pytest collective txn 1 - line 1, /subdir/file2.txt
-    2, 2024-05-24, 10022,                ,      USD,      99.00,                87.99, Test_VAT_code, pytest collective txn 1 - line 1,
-    3, 2024-04-24,      ,           10021,      EUR,     200.00,               175.55, Test_VAT_code, pytest collective txn 2 - line 1, /document-col-alt.pdf
-    3, 2024-04-24, 10021,                ,      EUR,     200.00,               175.55, Test_VAT_code, pytest collective txn 2 - line 2, /document-col-alt.pdf
-    4, 2024-05-24, 10022,           19992,      USD,     300.00,               450.45, Test_VAT_code, pytest single transaction 2,      /document-alt.pdf
-    5, 2024-04-04, 19993,                ,      CHF, -125000.00,           -125000.00,              , Convert -125'000 CHF to USD @ 1.10511,
-    5, 2024-04-04, 19992,                ,      USD,  138138.75,            125000.00,              , Convert -125'000 CHF to USD @ 1.10511,
-    6, 2024-04-04, 19993,                ,      CHF, -250000.00,                     ,              , Convert -250'000 CHF to USD @ 1.10511,
-    6, 2024-04-04, 19992,                ,      USD,  276277.50,            250000.00,              , Convert -250'000 CHF to USD @ 1.10511,
-    7, 2024-01-16,      ,           19991,      EUR,  125000.00,            125362.50,              , Convert 125'000 EUR to CHF, /2024/banking/IB/2023-01.pdf
-    7, 2024-01-16, 19993,                ,      CHF,  125362.50,            125362.50,              , Convert 125'000 EUR to CHF, /2024/banking/IB/2023-01.pdf
-    8, 2024-05-24, 10021,           19991,      EUR,     -10.00,                -9.00,              , Individual transaction with negative amount,
-    9, 2024-05-24, 10023,           19993,      CHF,     100.00,                     ,              , Collective transaction - leg with debit and credit account,
-    9, 2024-05-24, 10021,                ,      EUR,      20.00,                19.00,              , Collective transaction - leg with credit account,
-    9, 2024-05-24,      ,           19991,      EUR,      20.00,                19.00,              , Collective transaction - leg with debit account,
+    id,     date, account, counter_account, currency,     amount, base_currency_amount,      vat_code, text,                             document
+    1,  2024-05-24, 10023,           19993,      CHF,     100.00,                     , Test_VAT_code, pytest single transaction 1,      /file1.txt
+    2,  2024-05-24, 10022,                ,      USD,    -100.00,               -88.88, Test_VAT_code, pytest collective txn 1 - line 1, /subdir/file2.txt
+    2,  2024-05-24, 10022,                ,      USD,       1.00,                 0.89, Test_VAT_code, pytest collective txn 1 - line 1, /subdir/file2.txt
+    2,  2024-05-24, 10022,                ,      USD,      99.00,                87.99, Test_VAT_code, pytest collective txn 1 - line 1,
+    3,  2024-04-24,      ,           10021,      EUR,     200.00,               175.55, Test_VAT_code, pytest collective txn 2 - line 1, /document-col-alt.pdf
+    3,  2024-04-24, 10021,                ,      EUR,     200.00,               175.55, Test_VAT_code, pytest collective txn 2 - line 2, /document-col-alt.pdf
+    4,  2024-05-24, 10022,           19992,      USD,     300.00,               450.45, Test_VAT_code, pytest single transaction 2,      /document-alt.pdf
+    5,  2024-04-04, 19993,                ,      CHF, -125000.00,           -125000.00,              , Convert -125'000 CHF to USD @ 1.10511,
+    5,  2024-04-04, 19992,                ,      USD,  138138.75,            125000.00,              , Convert -125'000 CHF to USD @ 1.10511,
+    6,  2024-04-04, 19993,                ,      CHF, -250000.00,                     ,              , Convert -250'000 CHF to USD @ 1.10511,
+    6,  2024-04-04, 19992,                ,      USD,  276277.50,            250000.00,              , Convert -250'000 CHF to USD @ 1.10511,
+    7,  2024-01-16,      ,           19991,      EUR,  125000.00,            125362.50,              , Convert 125'000 EUR to CHF, /2024/banking/IB/2023-01.pdf
+    7,  2024-01-16, 19993,                ,      CHF,  125362.50,            125362.50,              , Convert 125'000 EUR to CHF, /2024/banking/IB/2023-01.pdf
+    8,  2024-05-24, 10021,           19991,      EUR,     -10.00,                -9.00,              , Individual transaction with negative amount,
+    9,  2024-05-24, 10023,           19993,      CHF,     100.00,                     ,              , Collective transaction - leg with debit and credit account,
+    9,  2024-05-24, 10021,                ,      EUR,      20.00,                19.00,              , Collective transaction - leg with credit account,
+    9,  2024-05-24,      ,           19991,      EUR,      20.00,                19.00,              , Collective transaction - leg with debit account,
+    10, 2024-05-24, 10023,           19993,      CHF,       0.00,                     ,              , Individual transaction with zero amount,
+    11, 2024-05-24, 10023,                ,      CHF,     100.00,                     , Test_VAT_code, Collective transaction with zero amount,
+    11, 2024-05-24, 19993,                ,      CHF,    -100.00,                     ,              , Collective transaction with zero amount,
+    11, 2024-05-24, 19993,                ,      CHF,       0.00,                     ,              , Collective transaction with zero amount,
 """
-
 LEDGER_ENTRIES = pd.read_csv(StringIO(LEDGER_CSV), skipinitialspace=True)
 TEST_ACCOUNTS = pd.read_csv(StringIO(ACCOUNT_CSV), skipinitialspace=True)
 TEST_VAT_CODE = pd.read_csv(StringIO(VAT_CSV), skipinitialspace=True)
@@ -251,6 +254,26 @@ def test_ledger_accessor_mutators_leg_with_credit_and_debit_account(set_up_vat_a
     # Collective transaction with credit and debit account in single line item
     cashctrl = CashCtrlLedger()
     target = LEDGER_ENTRIES.query('id == 9')
+    id = cashctrl.add_ledger_entry(target)
+    remote = cashctrl.ledger()
+    created = remote.loc[remote['id'] == str(id)]
+    expected = cashctrl.standardize_ledger(target)
+    assert_frame_equal(created, expected, ignore_index=True, ignore_columns=['id'])
+
+def test_ledger_accessor_mutators_transaction_with_zero_amount(set_up_vat_and_account):
+    # Individual transaction of zero base currency
+    cashctrl = CashCtrlLedger()
+    target = LEDGER_ENTRIES.query('id == 10')
+    id = cashctrl.add_ledger_entry(target)
+    remote = cashctrl.ledger()
+    created = remote.loc[remote['id'] == str(id)]
+    expected = cashctrl.standardize_ledger(target)
+    assert_frame_equal(created, expected, ignore_index=True, ignore_columns=['id'])
+
+def test_ledger_accessor_mutators_leg_with_zero_amount(set_up_vat_and_account):
+    # Collective transaction with leg of zero base currency
+    cashctrl = CashCtrlLedger()
+    target = LEDGER_ENTRIES.query('id == 11')
     id = cashctrl.add_ledger_entry(target)
     remote = cashctrl.ledger()
     created = remote.loc[remote['id'] == str(id)]


### PR DESCRIPTION
I encountered a series of errors when mirroring our company's general ledger for 2023.

This PR contains two commits for every encountered bug:

- The first commit extends the test coverage such that this bug is now detected by the integration tests. Tests on GitHub fail after each of those commits.
- The second commit fixes the bug. Tests on GitHub now pass again.


