### PR TITLE
Split Unmappable Transactions

### DIFF
--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -585,9 +585,13 @@ class CashCtrlLedger(LedgerEngine):
                  'deleted': count['n_delete'].sum() if delete else 0}
         return stats
 
-    def _get_ledger_attachments(self) -> Dict[str, List[str]]:
+    def _get_ledger_attachments(self, allow_missing=True) -> Dict[str, List[str]]:
         """
         Retrieves paths of files attached to CashCtrl ledger entries
+
+        Parameters:
+            allow_missing (boolean): If True, return None if the file has no path,
+                e.g. for files in the recylce bin. Otherwise raise a ValueError.
 
         Returns:
             Dict[str, List[str]]: A Dict that contains ledger ids with attached
@@ -597,8 +601,9 @@ class CashCtrlLedger(LedgerEngine):
         result = {}
         for id in ledger.loc[ledger['attachmentCount'] > 0, 'id']:
             res = self._client.get("journal/read.json", params={'id': id})['data']
-            paths = [self._client.file_id_to_path(attachment['fileId'])
-                     for attachment in res['attachments']]
+            paths = [
+                self._client.file_id_to_path(attachment['fileId'], allow_missing=allow_missing)
+                for attachment in res['attachments']]
             if len(paths):
                 result[id] = paths
         return result

--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -454,26 +454,20 @@ class CashCtrlLedger(LedgerEngine):
 
     def _add_fx_adjustment(self, entry: pd.DataFrame, transitory_account: int, base_currency: str) -> pd.DataFrame:
         """
-        Adds foreign exchange (FX) adjustments to ledger entries to ensure
-        accurate currency conversion based on the base currency.
+        Ensure amounts conform to CashCtrl's eight-digit FX rate precision.
 
-        This method adjusts the ledger entries to account for discrepancies
-        in currency conversion, ensuring that the base currency amounts are
-        accurately represented. It handles both individual and collective
-        transactions by either adjusting the existing entry or adding a
-        balancing transaction.
+        Adjusts the base currency amounts of a ledger entry to match CashCtrl's
+        eight-digit precision for exchange rates. Adds balancing ledger entries
+        if adjusted amounts differ from the original, ensuring the sum of all
+        entries remains consistent with the original entry.
 
         Args:
-            entry (pd.DataFrame): Individual or collective ledger entry or entries to adjust.
-            transitory_account (int): The account used for the balancing
-                                    transaction in collective transactions.
-            base_currency (str): The base currency used for adjustments.
+            entry (pd.DataFrame): Ledger entry data.
+            transitory_account (int): Account for balancing transactions.
+            base_currency (str): Base currency for adjustments.
 
         Returns:
-            pd.DataFrame: The adjusted ledger entries with FX adjustments included.
-
-        Raises:
-            ValueError: If the `entry` DataFrame is empty.
+            pd.DataFrame: Adjusted ledger entries with FX adjustments.
         """
         if len(entry) == 1:
             # Individual transaction: one row in the ledger data frame
@@ -516,14 +510,6 @@ class CashCtrlLedger(LedgerEngine):
                 if all(balance == 0.0):
                     return entry
                 else:
-                    # # Override with exchange rate derived from the largest absolute amount
-                    # fx = entry.loc[entry['currency'] != base_currency]
-                    # is_max_abs = fx['amount'].abs() == fx['amount'].abs().max()
-                    # fx_rate = (fx['base_currency_amount'] / fx['amount']).loc[is_max_abs].iat[0]
-                    # fx_rate = round(fx_rate, 8)
-                    # balance = np.where(entry['currency'] == base_currency,
-                    #     amount - ((amount / fx_rate).round(2) * fx_rate).round(2),
-                    #     base_amount - (amount * fx_rate).round(2))
                     is_base_currency = entry['currency'] == base_currency
                     balancing_txn = entry.head(1).copy()
                     balancing_txn['currency'] = base_currency

--- a/tests/test_account_chart.py
+++ b/tests/test_account_chart.py
@@ -34,6 +34,7 @@ TEST_ACCOUNTS = pd.read_csv(StringIO(ACCOUNT_CSV), skipinitialspace=True)
 @pytest.fixture(scope="module")
 def set_up_vat_account_and_ledger():
     cashctrl = CashCtrlLedger()
+    cashctrl.transitory_account = 19993
 
     # Fetch original state
     initial_account_chart = cashctrl.account_chart().reset_index()

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -56,6 +56,10 @@ LEDGER_CSV = """
     11, 2024-05-24, 19993,                ,      CHF,       0.00,                     ,              , Collective transaction with zero amount,
     12, 2024-03-02,      ,           19991,      EUR,  600000.00,            599580.00,              , Convert 600k EUR to CHF @ 0.9993,
     12, 2024-03-02, 19993,                ,      CHF,  599580.00,            599580.00,              , Convert 600k EUR to CHF @ 0.9993,
+        # FX gain/loss: transactions in base currency with zero foreign currency amount
+    13, 2024-06-26, 10022,           19993,      CHF,       0.00,               999.00,              , Foreign currency adjustment
+    14, 2024-06-26, 10021,                ,      EUR,       0.00,                 5.55,              , Foreign currency adjustment
+    14, 2024-06-26,      ,           19993,      CHF,       5.55,                     ,              , Foreign currency adjustment
 """
 STRIPPED_CSV = '\n'.join([line.strip() for line in LEDGER_CSV.split("\n")])
 LEDGER_ENTRIES = pd.read_csv(StringIO(STRIPPED_CSV), skipinitialspace=True, comment="#", skip_blank_lines=True)

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -109,7 +109,7 @@ def test_add_ledger_entry(set_up_vat_and_account, ledger_id):
     remote = cashctrl.ledger()
     created = remote.loc[remote['id'] == str(id)]
     expected = cashctrl.standardize_ledger(target)
-    assert_frame_equal(created, expected, ignore_index=True, ignore_columns=['id'])
+    assert_frame_equal(created, expected, ignore_index=True, ignore_columns=['id'], check_exact=True)
 
 def test_ledger_accessor_mutators_single_transaction(set_up_vat_and_account):
     cashctrl = CashCtrlLedger()

--- a/tests/test_ledger.py
+++ b/tests/test_ledger.py
@@ -381,6 +381,8 @@ def test_mirror_ledger(set_up_vat_and_account):
     expected = cashctrl.sanitize_ledger(expected)
     expected = pd.concat([mirrored, expected])
     mirrored = cashctrl.ledger()
+    # set(txn_to_str(mirrored)).difference(txn_to_str(expected))
+    # set(txn_to_str(expected)).difference(txn_to_str(mirrored))
     assert txn_to_str(mirrored) == txn_to_str(expected)
 
     # Mirror existing transactions with delete=False has no impact


### PR DESCRIPTION
Split transactions that can not be mapped to CashCtrl into multiple transactions that can be mapped to CashCtrl and lead in sum to the same account balance.

This PR introduces a series of transactions that can not be mapped to CashCtrl and then extends CashCtrlClient to split such transactions into collective or multiple transactions that can be mapped. The PR is best reviewed commit by commit.
- 0dc2720  Extend tests to cover FX gain/loss transactions that can not be mapped ATM (expected to fail)
- 0381bc2  Support FX gain/loss transactions (the test introduced above now passes)
- 1d5eba0  Split multi-currency transactions into multiple single-currency transactions
- 7c57683  Ensure integration tests catch approximate equality
- e90655f  Extend tests to cover transactions requiring high precision FX rates (expected to fail)
- 82531a9  Support transactions requiring high precision FX rates (the test introduced above now passes)
- f061a45   Avoid unneeded exceptions when transactions requiring high precision FX rates
- 3817155 _get_ledger_attachement does not raise error if file is located in the recycle bin.