### PR TITLE
Feat: implement price() method

### DIFF
--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -979,9 +979,24 @@ class CashCtrlLedger(LedgerEngine):
         """
         return 0.01
 
-    def price(self):
-        """Not implemented yet."""
-        raise NotImplementedError
+    def price(self, currency: str, date: datetime.date = None) -> float:
+        """
+        Retrieves the price of a given currency in terms of the base currency on
+        a specific date.
+
+        Args:
+            currency (str): The currency code to retrieve the price for.
+            date (datetime.date, optional): The date for which the price is
+                requested. Defaults to None, which retrieves the latest price.
+
+        Returns:
+            float: The price of the currency in terms of the base currency.
+        """
+        return self._client.get_exchange_rate(
+            from_currency=currency,
+            to_currency=self.base_currency,
+            date=date
+        )
 
     def add_price(self):
         """Not implemented yet."""

--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -981,8 +981,8 @@ class CashCtrlLedger(LedgerEngine):
 
     def price(self, currency: str, date: datetime.date = None) -> float:
         """
-        Retrieves the price of a given currency in terms of the base currency on
-        a specific date.
+        Retrieves the price (exchange rate) of a given currency in terms
+        of the base currency.
 
         Args:
             currency (str): The currency code to retrieve the price for.
@@ -990,7 +990,7 @@ class CashCtrlLedger(LedgerEngine):
                 requested. Defaults to None, which retrieves the latest price.
 
         Returns:
-            float: The price of the currency in terms of the base currency.
+            float: The exchange rate between the currency and the base currency.
         """
         return self._client.get_exchange_rate(
             from_currency=currency,
@@ -999,19 +999,16 @@ class CashCtrlLedger(LedgerEngine):
         )
 
     def add_price(self):
-        """Not implemented yet."""
         raise NotImplementedError(
-            "Cashctrl doesn't support manually adding the price of currencies."
+            "Cashctrl doesn't support adding exchange rates through the API."
         )
 
     def delete_price(self):
-        """Not implemented yet."""
         raise NotImplementedError(
-            "Cashctrl doesn't support manually deleting the price of currencies."
+            "Cashctrl doesn't support deleting exchange rates through the API."
         )
 
     def price_history(self):
-        """Not implemented yet."""
         raise NotImplementedError(
-            "Cashctrl doesn't support reading of price change history."
+            "Cashctrl doesn't support reading the exchange rate history through the API."
         )

--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -1000,12 +1000,18 @@ class CashCtrlLedger(LedgerEngine):
 
     def add_price(self):
         """Not implemented yet."""
-        raise NotImplementedError
-
-    def price_history(self):
-        """Not implemented yet."""
-        raise NotImplementedError
+        raise NotImplementedError(
+            "Cashctrl doesn't support manually adding the price of currencies."
+        )
 
     def delete_price(self):
         """Not implemented yet."""
-        raise NotImplementedError
+        raise NotImplementedError(
+            "Cashctrl doesn't support manually deleting the price of currencies."
+        )
+
+    def price_history(self):
+        """Not implemented yet."""
+        raise NotImplementedError(
+            "Cashctrl doesn't support reading of price change history."
+        )

--- a/tests/test_currencies.py
+++ b/tests/test_currencies.py
@@ -1,0 +1,32 @@
+"""Unit tests for currencies."""
+
+from cashctrl_ledger import CashCtrlLedger
+import pytest
+
+
+CURRENCY = {"code": "AAA", "rate": 0.11111}
+
+
+@pytest.fixture(scope="module")
+def currency():
+    cashctrl = CashCtrlLedger()
+    res = cashctrl._client.post("currency/create.json", data=CURRENCY)
+
+    yield
+
+    cashctrl._client.post("currency/delete.json", data={"ids": res["insertId"]})
+
+
+def test_price_for_base_currency():
+    cashctrl_ledger = CashCtrlLedger()
+
+    price = cashctrl_ledger.price(cashctrl_ledger.base_currency)
+    assert price == 1, "Price for base currency should be 1."
+
+
+@pytest.mark.skip(reason="Cashctrl doesn't support looking up exchange rates for custom currencies")
+def test_price_for_currency(currency):
+    cashctrl_ledger = CashCtrlLedger()
+
+    price = cashctrl_ledger.price(currency=CURRENCY["code"])
+    assert price == 0.11111, f"Price for {CURRENCY["code"]} should be {CURRENCY["rate"]}"


### PR DESCRIPTION
### This PR covers adding of `price()` method


**Limitations and details:**
- There is no way to receive a `history` of price changes. The `"currency/exchangerate"` endpoint is the only one to calculate the `exchange rate` and it returns `only one` float value at a time
- We can not look up for a custom currency exchange rate. My goal was to test an exchange rate for a created currency. After creating a custom currency using the `currency/create.json` endpoint and trying to receive its rate from the `"currency/exchangerate"` endpoint it returns an empty string and doesn't see a new currency
- Test action will fail until https://github.com/macxred/cashctrl_api/pull/44 is merged

@lasuk Please review the changes and provide feedback or approval for merging.