### PR TITLE
Feat: implement precision() an use round_series_to_precision()

### DIFF
--- a/cashctrl_ledger/extended_ledger.py
+++ b/cashctrl_ledger/extended_ledger.py
@@ -228,11 +228,11 @@ class ExtendedCashCtrlLedger(CashCtrlLedger):
                             self.standardize_ledger_columns(balancing_txn),
                         ]
                     )
-                    result["amount"] = self.round_series_to_precision(
+                    result["amount"] = self.round_to_precision(
                         result["amount"], result["currency"]
                     )
-                    result["base_currency_amount"] = self.round_series_to_precision(
-                        result["base_currency_amount"], pd.Series([base_currency] * len(result))
+                    result["base_currency_amount"] = self.round_to_precision(
+                        result["base_currency_amount"], base_currency
                     )
                     return self.standardize_ledger(result)
 
@@ -245,20 +245,17 @@ class ExtendedCashCtrlLedger(CashCtrlLedger):
             if currency == base_currency:
                 return entry
             else:
-                entry["amount"] = self.round_series_to_precision(
-                    entry["amount"], entry["currency"]
-                )
-                entry["base_currency_amount"] = self.round_series_to_precision(
-                    entry["base_currency_amount"],
-                    pd.Series([base_currency] * len(entry))
+                entry["amount"] = self.round_to_precision(entry["amount"], entry["currency"])
+                entry["base_currency_amount"] = self.round_to_precision(
+                    entry["base_currency_amount"], base_currency,
                 )
                 balance = np.where(
                     entry["currency"] == base_currency,
-                    entry["amount"] - self.round_to_precision(
-                        entry["amount"] / fx_rate, currency
+                    entry["amount"] - np.array(
+                        self.round_to_precision(entry["amount"] / fx_rate, currency)
                     ) * fx_rate,
-                    entry["base_currency_amount"] - self.round_to_precision(
-                        entry["amount"] * fx_rate, base_currency
+                    entry["base_currency_amount"] - np.array(
+                        self.round_to_precision(entry["amount"] * fx_rate, base_currency)
                     ),
                 )
                 if all(balance == 0.0):
@@ -296,11 +293,11 @@ class ExtendedCashCtrlLedger(CashCtrlLedger):
                     fx_adjust["text"] = "Currency adjustments: " + fx_adjust["text"]
                     fx_adjust = fx_adjust[balance != 0]
                     result = pd.concat([entry, fx_adjust])
-                    result["amount"] = self.round_series_to_precision(
+                    result["amount"] = self.round_to_precision(
                         result["amount"], result["currency"]
                     )
-                    result["base_currency_amount"] = self.round_series_to_precision(
-                        result["base_currency_amount"], pd.Series([base_currency] * len(result))
+                    result["base_currency_amount"] = self.round_to_precision(
+                        result["base_currency_amount"], base_currency
                     )
                     return self.standardize_ledger(result)
 

--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -921,7 +921,7 @@ class CashCtrlLedger(LedgerEngine):
                 elif row["currency"] == currency:
                     amount = row["amount"]
                 elif row["currency"] == base_currency:
-                    amount = self.round_to_precision(row["amount"] / fx_rate, currency)
+                    amount = row["amount"] / fx_rate
                 else:
                     raise ValueError(
                         "Currencies other than base or transaction currency are not "

--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -18,7 +18,18 @@ class CashCtrlLedger(LedgerEngine):
     usage examples.
     """
 
-    _settings = None
+    _precision = {
+        "AUD": 0.01,
+        "CAD": 0.01,
+        "CHF": 0.01,
+        "EUR": 0.01,
+        "GBP": 0.01,
+        "JPY": 1.00,
+        "NZD": 0.01,
+        "NOK": 0.01,
+        "SEK": 0.01,
+        "USD": 0.01,
+    }
 
     # ----------------------------------------------------------------------
     # Constructor
@@ -26,22 +37,6 @@ class CashCtrlLedger(LedgerEngine):
     def __init__(self, client: Union[CachedCashCtrlClient, None] = None):
         super().__init__()
         self._client = CachedCashCtrlClient() if client is None else client
-
-    # ----------------------------------------------------------------------
-    # Settings
-
-    @property
-    def settings(self):
-        """Get the settings."""
-        return self._settings
-
-    @settings.setter
-    def settings(self, new_settings):
-        """Set the settings."""
-        if isinstance(new_settings, dict):
-            self._settings = new_settings
-        else:
-            raise ValueError("Settings must be a dictionary")
 
     # ----------------------------------------------------------------------
     # VAT codes
@@ -982,21 +977,17 @@ class CashCtrlLedger(LedgerEngine):
             raise ValueError("Multiple base currencies defined.")
 
     def precision(self, ticker: str, date: datetime.date = None) -> float:
-        """Returns the precision for given currencies.
+        return self._precision.get(ticker, 0.01)
+
+    def set_precision(self, ticker: str, precision: float):
+        """
+        Set the precision or minimal price increment for a given asset or currency.
 
         Args:
-            ticker (str): Reference to the associated document.
-            date (datetime.date, optional): Date for which to retrieve the precision.
-                                            Default is None.
-
-        Returns:
-            float: The precision value.
+            ticker (str): Unique identifier of the currency or asset.
+            precision (float): Minimal price increment to round to.
         """
-        if not self._settings:
-            return 0.01
-
-        precision_settings = self._settings.get("precision", {})
-        return precision_settings.get(ticker, 0.01)
+        self._precision[ticker] = precision
 
     def price(self, currency: str, date: datetime.date = None) -> float:
         """

--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -496,7 +496,7 @@ class CashCtrlLedger(LedgerEngine):
                 "account": collective["account"],
                 "text": collective["description"],
                 "amount": self.round_to_precision(foreign_amount, currency),
-                "base_currency_amount": self.round_to_precision(base_amount, currency),
+                "base_currency_amount": self.round_to_precision(base_amount, base_currency),
                 "vat_code": collective["taxName"],
                 "document": collective["document"]
             })
@@ -857,7 +857,7 @@ class CashCtrlLedger(LedgerEngine):
                 fx_entries["amount"] * fx_rate, self.base_currency,
             )
             expected_rounded_amounts = self.round_to_precision(
-                fx_entries["base_currency_amount"], fx_entries["currency"]
+                fx_entries["base_currency_amount"], self.base_currency
             )
             if rounded_amounts != expected_rounded_amounts:
                 raise ValueError("Incoherent FX rates in collective booking.")

--- a/tests/test_currencies.py
+++ b/tests/test_currencies.py
@@ -5,6 +5,11 @@ import pytest
 
 
 CURRENCY = {"code": "AAA", "rate": 0.11111}
+SETTINGS = {
+    "precision": {
+        "USD": 0.0001,
+    },
+}
 
 
 @pytest.fixture(scope="module")
@@ -30,3 +35,16 @@ def test_price_for_currency(currency):
 
     price = cashctrl_ledger.price(currency=CURRENCY["code"])
     assert price == 0.11111, f"Price for {CURRENCY["code"]} should be {CURRENCY["rate"]}"
+
+
+def test_precision():
+    cashctrl_ledger = CashCtrlLedger()
+
+    precision = cashctrl_ledger.precision("USD")
+    assert precision == 0.01, "Default precision should be 0.01"
+
+    cashctrl_ledger.settings = SETTINGS
+    precision = cashctrl_ledger.precision("USD")
+    assert precision == SETTINGS["precision"]["USD"], (
+        f"Precision for USD should be {SETTINGS['precision']['USD']}"
+    )

--- a/tests/test_currencies.py
+++ b/tests/test_currencies.py
@@ -5,11 +5,6 @@ import pytest
 
 
 CURRENCY = {"code": "AAA", "rate": 0.11111}
-SETTINGS = {
-    "precision": {
-        "USD": 0.0001,
-    },
-}
 
 
 @pytest.fixture(scope="module")
@@ -43,8 +38,6 @@ def test_precision():
     precision = cashctrl_ledger.precision("USD")
     assert precision == 0.01, "Default precision should be 0.01"
 
-    cashctrl_ledger.settings = SETTINGS
+    cashctrl_ledger.set_precision("USD", 0.0001)
     precision = cashctrl_ledger.precision("USD")
-    assert precision == SETTINGS["precision"]["USD"], (
-        f"Precision for USD should be {SETTINGS['precision']['USD']}"
-    )
+    assert cashctrl_ledger.precision("USD") == 0.0001, "Precision for USD should be 0.0001"


### PR DESCRIPTION
### This PR removes TODO comments related to rounding by implementing the `round_series_to_precision()` method.

Key points:

- Replaced hard-coded rounding logic with the newly introduced `round_series_to_precision()` method.
- Ensured consistent rounding across the codebase, improving precision handling for both individual and vectorized operations.
- Removed all associated TODO comments, as the new method fully addresses the previously deferred rounding logic.
- This PR action will fail until https://github.com/macxred/pyledger/pull/18 is merged

@lasuk Please review the changes and provide feedback or approval for merging