### PR TITLE
Feat: move mirroring logic to pyledger

### DIFF
--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -3,7 +3,7 @@
 from datetime import datetime
 from typing import Dict, List, Tuple, Union
 from cashctrl_api import CachedCashCtrlClient
-from consistent_df import df_to_consistent_str, nest, unnest, enforce_dtypes
+from consistent_df import unnest, enforce_dtypes
 import numpy as np
 import pandas as pd
 import zipfile
@@ -226,51 +226,6 @@ class CashCtrlLedger(LedgerEngine):
             self._client.post("tax/delete.json", {"ids": delete_id})
             self._client.invalidate_tax_rates_cache()
 
-    def mirror_vat_codes(self, target: pd.DataFrame, delete: bool = False):
-        """Aligns VAT rates on the remote CashCtrl account with
-        the desired state provided as a DataFrame.
-
-        Args:
-            target (pd.DataFrame): DataFrame containing VAT rates in
-                                         the pyledger.vat_codes format.
-            delete (bool, optional): If True, deletes VAT codes on the remote account
-                                     that are not present in target_state.
-        """
-        target_df = StandaloneLedger.standardize_vat_codes(target).reset_index()
-        current_state = self.vat_codes().reset_index()
-
-        # Delete superfluous VAT codes on remote
-        if delete:
-            for idx in set(current_state["id"]).difference(set(target_df["id"])):
-                self.delete_vat_code(code=idx)
-
-        # Create new VAT codes on remote
-        ids = set(target_df["id"]).difference(set(current_state["id"]))
-        to_add = target_df.loc[target_df["id"].isin(ids)]
-        for row in to_add.to_dict("records"):
-            self.add_vat_code(
-                code=row["id"],
-                text=row["text"],
-                account=row["account"],
-                rate=row["rate"],
-                inclusive=row["inclusive"],
-            )
-
-        # Update modified VAT cods on remote
-        both = set(target_df["id"]).intersection(set(current_state["id"]))
-        left = target_df.loc[target_df["id"].isin(both)]
-        right = current_state.loc[current_state["id"].isin(both)]
-        merged = pd.merge(left, right, how="outer", indicator=True)
-        to_update = merged[merged["_merge"] == "left_only"]
-        for row in to_update.to_dict("records"):
-            self.modify_vat_code(
-                code=row["id"],
-                text=row["text"],
-                account=row["account"],
-                rate=row["rate"],
-                inclusive=row["inclusive"],
-            )
-
     # ----------------------------------------------------------------------
     # Accounts
 
@@ -386,6 +341,9 @@ class CashCtrlLedger(LedgerEngine):
         """Synchronizes remote CashCtrl accounts with a desired target state
         provided as a DataFrame.
 
+        Updates existing categories before creating accounts and then invokes
+        the parent class method.
+
         Args:
             target (pd.DataFrame): DataFrame with an account chart in the pyledger format.
             delete (bool, optional): If True, deletes accounts on the remote that are not
@@ -399,12 +357,6 @@ class CashCtrlLedger(LedgerEngine):
             self.delete_accounts(
                 set(current_state["account"]).difference(set(target_df["account"]))
             )
-
-        # Create new accounts on remote
-        accounts = set(target_df["account"]).difference(
-            set(current_state["account"])
-        )
-        to_add = target_df.loc[target_df["account"].isin(accounts)]
 
         # Update account categories
         def get_nodes_list(path: str) -> List[str]:
@@ -428,31 +380,7 @@ class CashCtrlLedger(LedgerEngine):
             delete=delete,
             ignore_account_root_nodes=True,
         )
-
-        for row in to_add.to_dict("records"):
-            self.add_account(
-                account=row["account"],
-                currency=row["currency"],
-                text=row["text"],
-                vat_code=row["vat_code"],
-                group=row["group"],
-            )
-
-        # Update modified accounts on remote
-        both = set(target_df["account"]).intersection(set(current_state["account"]))
-        left = target_df.loc[target_df["account"].isin(both)]
-        right = current_state.loc[current_state["account"].isin(both)]
-        merged = pd.merge(left, right, how="outer", indicator=True)
-        to_update = merged[merged["_merge"] == "left_only"]
-
-        for row in to_update.to_dict("records"):
-            self.modify_account(
-                account=row["account"],
-                currency=row["currency"],
-                text=row["text"],
-                vat_code=row["vat_code"],
-                group=row["group"],
-            )
+        super().mirror_account_chart(target, delete)
 
     def _single_account_balance(
         self, account: int, date: Union[datetime.date, None] = None
@@ -647,86 +575,6 @@ class CashCtrlLedger(LedgerEngine):
             ids = ",".join(ids)
         self._client.post("journal/delete.json", {"ids": ids})
         self._client.invalidate_journal_cache()
-
-    def mirror_ledger(self, target: pd.DataFrame, delete: bool = False):
-        """Mirrors the ledger data to the remote CashCtrl instance.
-
-        Args:
-            target (pd.DataFrame): DataFrame containing ledger data in pyledger format.
-            delete (bool, optional): If True, deletes ledger entries on the remote that are
-                                     not present in the target DataFrame.
-        """
-        # Standardize data frame schema, discard incoherent entries with a warning
-        target = self.standardize_ledger(target)
-        target = self.sanitize_ledger(target)
-
-        # Nest to create one row per transaction, add unique string identifier
-        def process_ledger(df: pd.DataFrame) -> pd.DataFrame:
-            df = nest(
-                df,
-                columns=[col for col in df.columns if col not in ["id", "date"]],
-                key="txn",
-            )
-            df["txn_str"] = [
-                f"{str(date)},{df_to_consistent_str(txn)}"
-                for date, txn in zip(df["date"], df["txn"])
-            ]
-            return df
-
-        remote = process_ledger(self.ledger())
-        target = process_ledger(target)
-        if target["id"].duplicated().any():
-            # We expect nesting to combine all rows with the same
-            raise ValueError("Non-unique dates in `target` transactions.")
-
-        # Count occurrences of each unique transaction in target and remote,
-        # find number of additions and deletions for each unique transaction
-        count = pd.DataFrame({
-            "remote": remote["txn_str"].value_counts(),
-            "target": target["txn_str"].value_counts(),
-        })
-        count = count.fillna(0).reset_index(names="txn_str")
-        count["n_add"] = (count["target"] - count["remote"]).clip(lower=0).astype(int)
-        count["n_delete"] = (count["remote"] - count["target"]).clip(lower=0).astype(int)
-
-        # Delete unneeded transactions on remote
-        if delete and any(count["n_delete"] > 0):
-            ids = [
-                id
-                for txn_str, n in zip(count["txn_str"], count["n_delete"])
-                if n > 0
-                for id in remote.loc[remote["txn_str"] == txn_str, "id"]
-                .tail(n=n)
-                .values
-            ]
-            self.delete_ledger_entry(ids=",".join(ids))
-
-        # Add missing transactions to remote
-        for txn_str, n in zip(count["txn_str"], count["n_add"]):
-            if n > 0:
-                txn = unnest(
-                    target.loc[target["txn_str"] == txn_str, :].head(1), "txn"
-                )
-                if txn["id"].dropna().nunique() > 0:
-                    id = txn["id"].dropna().unique()[0]
-                else:
-                    id = txn["text"].iat[0]
-                for _ in range(n):
-                    try:
-                        self.add_ledger_entry(txn)
-                    except Exception as e:
-                        raise Exception(
-                            f"Error while adding ledger entry {id}: {e}"
-                        ) from e
-
-        # return number of elements found, targeted, changed:
-        stats = {
-            "pre-existing": int(count["remote"].sum()),
-            "targeted": int(count["target"].sum()),
-            "added": count["n_add"].sum(),
-            "deleted": count["n_delete"].sum() if delete else 0,
-        }
-        return stats
 
     def standardize_ledger(self, ledger: pd.DataFrame) -> pd.DataFrame:
         """Standardizes the ledger DataFrame to conform to CashCtrl format.

--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -214,13 +214,6 @@ class CashCtrlLedger(LedgerEngine):
         self._client.invalidate_tax_rates_cache()
 
     def delete_vat_codes(self, codes: List[str] = [], allow_missing: bool = False):
-        """Deletes a VAT codes from the remote CashCtrl account.
-
-        Args:
-            codes (List[str]): The VAT code names to be deleted.
-            allow_missing (bool, optional): If True, no error is raised if the VAT code is not
-                                            found; if False, raises ValueError. Defaults to False.
-        """
         ids = []
         for code in codes:
             id = self._client.tax_code_to_id(code, allow_missing=allow_missing)
@@ -313,13 +306,6 @@ class CashCtrlLedger(LedgerEngine):
         self._client.invalidate_accounts_cache()
 
     def delete_accounts(self, accounts: List[int] = [], allow_missing: bool = False):
-        """Deletes accounts from the remote CashCtrl instance.
-
-        Args:
-            accounts (int[]): The account numbers to be deleted.
-            allow_missing (bool, optional): If True, do not raise an error if the
-                                            account is missing. Defaults to False.
-        """
         ids = []
         for account in accounts:
             id = self._client.account_to_id(account, allow_missing)
@@ -558,12 +544,7 @@ class CashCtrlLedger(LedgerEngine):
         self._client.invalidate_journal_cache()
 
     def delete_ledger_entries(self, ids: List[str] = []):
-        """Deletes a ledger entry from the remote CashCtrl instance.
-
-        Args:
-            ids (List[str]): The Ids of the ledger entries to be deleted.
-        """
-        self._client.post("journal/delete.json", {"ids": ",".join(ids)})
+        self._client.post("journal/delete.json", {"ids": ",".join([str(id) for id in ids])})
         self._client.invalidate_journal_cache()
 
     def standardize_ledger(self, ledger: pd.DataFrame) -> pd.DataFrame:

--- a/cashctrl_ledger/tests/test_account_chart.py
+++ b/cashctrl_ledger/tests/test_account_chart.py
@@ -85,10 +85,10 @@ class TestAccounts(BaseTestAccounts):
             ledger, error_class=ValueError, error_message="No id found for account"
         )
     def test_delete_non_existing_account_raise_error(self, ledger):
-        ledger.delete_account(1141, allow_missing=True)
+        ledger.delete_accounts([1141], allow_missing=True)
         assert 1141 not in ledger.account_chart()["account"].values
         with pytest.raises(ValueError):
-            ledger.delete_account(1141)
+            ledger.delete_accounts([1141])
 
     def test_add_account_with_invalid_currency_error(self, ledger):
         with pytest.raises(ValueError):

--- a/cashctrl_ledger/tests/test_ledger.py
+++ b/cashctrl_ledger/tests/test_ledger.py
@@ -97,7 +97,7 @@ class TestLedger(BaseTestLedger):
             ledger.modify_ledger_entry(target)
 
         # Delete the ledger entry created above
-        ledger.delete_ledger_entries([str(id)])
+        ledger.delete_ledger_entries([id])
 
     def test_update_non_existent_ledger(self, ledger):
         target = self.LEDGER_ENTRIES.query("id == 1").copy()

--- a/cashctrl_ledger/tests/test_ledger.py
+++ b/cashctrl_ledger/tests/test_ledger.py
@@ -97,7 +97,7 @@ class TestLedger(BaseTestLedger):
             ledger.modify_ledger_entry(target)
 
         # Delete the ledger entry created above
-        ledger.delete_ledger_entry(id)
+        ledger.delete_ledger_entries([str(id)])
 
     def test_update_non_existent_ledger(self, ledger):
         target = self.LEDGER_ENTRIES.query("id == 1").copy()
@@ -107,7 +107,7 @@ class TestLedger(BaseTestLedger):
 
     def test_delete_non_existent_ledger(self, ledger):
         with pytest.raises(RequestException):
-            ledger.delete_ledger_entry(ids="non-existent")
+            ledger.delete_ledger_entries(ids=["non-existent"])
 
     def test_split_multi_currency_transactions(self, ledger):
         transitory_account = 9995

--- a/cashctrl_ledger/tests/test_ledger_attachments.py
+++ b/cashctrl_ledger/tests/test_ledger_attachments.py
@@ -71,7 +71,7 @@ def ledger_ids():
     yield ledger_ids
 
     # Restore original ledger state
-    engine.delete_ledger_entries([str(id) for id in ledger_ids])
+    engine.delete_ledger_entries(ledger_ids)
 
 
 @pytest.fixture(scope="module")
@@ -88,7 +88,7 @@ def ledger_attached_ids():
     yield ledger_ids
 
     # Restore original ledger state
-    cashctrl.delete_ledger_entries([str(id) for id in ledger_ids])
+    cashctrl.delete_ledger_entries(ledger_ids)
 
 
 def sort_dict_values(items):

--- a/cashctrl_ledger/tests/test_ledger_attachments.py
+++ b/cashctrl_ledger/tests/test_ledger_attachments.py
@@ -71,7 +71,7 @@ def ledger_ids():
     yield ledger_ids
 
     # Restore original ledger state
-    engine.delete_ledger_entry([str(id) for id in ledger_ids])
+    engine.delete_ledger_entries([str(id) for id in ledger_ids])
 
 
 @pytest.fixture(scope="module")
@@ -88,7 +88,7 @@ def ledger_attached_ids():
     yield ledger_ids
 
     # Restore original ledger state
-    cashctrl.delete_ledger_entry([str(id) for id in ledger_ids])
+    cashctrl.delete_ledger_entries([str(id) for id in ledger_ids])
 
 
 def sort_dict_values(items):

--- a/cashctrl_ledger/tests/test_vat_code.py
+++ b/cashctrl_ledger/tests/test_vat_code.py
@@ -21,7 +21,7 @@ class TestVatCodes(BaseTestVatCode):
         super().test_update_non_existent_raise_error(ledger, error_message="No id found for tax code")
 
     def test_add_vat_with_not_valid_account_raise_error(self, ledger):
-        ledger.delete_account(8888, allow_missing=True)
+        ledger.delete_accounts([8888], allow_missing=True)
         assert 8888 not in ledger.account_chart()["account"].values
         with pytest.raises(ValueError):
             ledger.add_vat_code(
@@ -29,7 +29,7 @@ class TestVatCodes(BaseTestVatCode):
             )
 
     def test_update_vat_with_not_valid_account_raise_error(self, ledger):
-        ledger.delete_account(8888, allow_missing=True)
+        ledger.delete_accounts([8888], allow_missing=True)
         assert 8888 not in ledger.account_chart()["account"].values
         with pytest.raises(ValueError):
             ledger.modify_vat_code(
@@ -37,9 +37,9 @@ class TestVatCodes(BaseTestVatCode):
             )
 
     def test_delete_vat_non_existent(self, ledger):
-        ledger.delete_vat_code("TestCode", allow_missing=True)
+        ledger.delete_vat_codes(["TestCode"], allow_missing=True)
         assert "TestCode" not in ledger.vat_codes()["id"].values
 
     def test_delete_non_existent_vat_raise_error(self, ledger):
         with pytest.raises(ValueError):
-            ledger.delete_vat_code("TestCode")
+            ledger.delete_vat_codes(["TestCode"])


### PR DESCRIPTION

### Summary of Changes:

1. **Moved Mirroring Methods to `pyledger`**:  
   The mirroring methods have been refactored and relocated to the `pyledger` module for better modularity and maintainability.

2. **Updated Delete Methods to Accept Only Lists**:  
   The delete methods have been updated to strictly accept lists as input. This ensures consistency and simplifies handling of multiple values.
