### PR TITLE
Restore accounts and tax codes in preparation of #83

### DIFF
--- a/cashctrl_ledger/accounts.py
+++ b/cashctrl_ledger/accounts.py
@@ -1,0 +1,166 @@
+def accounts(self) -> pd.DataFrame:
+    """Retrieves the accounts from a remote CashCtrl instance,
+    formatted to the pyledger schema.
+
+    Returns:
+        pd.DataFrame: A DataFrame with the accounts in pyledger format.
+    """
+    accounts = self._client.list_accounts()
+    result = pd.DataFrame(
+        {
+            "account": accounts["number"],
+            "currency": accounts["currencyCode"],
+            "description": accounts["name"],
+            "tax_code": accounts["taxName"],
+            "group": accounts["path"],
+        }
+    )
+    return self.standardize_accounts(result)
+
+def add_account(
+    self,
+    account: str,
+    currency: str,
+    description: str,
+    group: str,
+    tax_code: Union[str, None] = None,
+):
+    """Adds a new account to the remote CashCtrl instance.
+
+    Args:
+        account (str): The account number or identifier to be added.
+        currency (str): The currency associated with the account.
+        description (str): Description associated with the account.
+        group (str): The category group to which the account belongs.
+        tax_code (str, optional): The tax code to be applied to the account, if any.
+    """
+    payload = {
+        "number": account,
+        "currencyId": self._client.currency_to_id(currency),
+        "name": description,
+        "taxId": None
+        if pd.isna(tax_code)
+        else self._client.tax_code_to_id(tax_code),
+        "categoryId": self._client.account_category_to_id(group),
+    }
+    self._client.post("account/create.json", data=payload)
+    self._client.invalidate_accounts_cache()
+
+def modify_account(
+    self,
+    account: str,
+    currency: str,
+    description: str,
+    group: str,
+    tax_code: Union[str, None] = None,
+):
+    """Updates an existing account in the remote CashCtrl instance.
+
+    Args:
+        account (str): The account number or identifier to be added.
+        currency (str): The currency associated with the account.
+        description (str): Description associated with the account.
+        group (str): The category group to which the account belongs.
+        tax_code (str, optional): The tax code to be applied to the account, if any.
+    """
+    payload = {
+        "id": self._client.account_to_id(account),
+        "number": account,
+        "currencyId": self._client.currency_to_id(currency),
+        "name": description,
+        "taxId": None
+        if pd.isna(tax_code)
+        else self._client.tax_code_to_id(tax_code),
+        "categoryId": self._client.account_category_to_id(group),
+    }
+    self._client.post("account/update.json", data=payload)
+    self._client.invalidate_accounts_cache()
+
+def delete_accounts(self, accounts: List[int] = [], allow_missing: bool = False):
+    ids = []
+    for account in accounts:
+        id = self._client.account_to_id(account, allow_missing)
+        if id is not None:
+            ids.append(str(id))
+    if len(ids):
+        self._client.post("account/delete.json", {"ids": ", ".join(ids)})
+        self._client.invalidate_accounts_cache()
+
+def mirror_accounts(self, target: pd.DataFrame, delete: bool = False):
+    """Synchronizes remote CashCtrl accounts with a desired target state
+    provided as a DataFrame.
+
+    Updates existing categories before creating accounts and then invokes
+    the parent class method.
+
+    Args:
+        target (pd.DataFrame): DataFrame with an account chart in the pyledger format.
+        delete (bool, optional): If True, deletes accounts on the remote that are not
+                                  present in the target DataFrame.
+    """
+    target_df = StandaloneLedger.standardize_accounts(target).reset_index()
+    current_state = self.accounts().reset_index()
+
+    # Delete superfluous accounts on remote
+    if delete:
+        self.delete_accounts(
+            set(current_state["account"]).difference(set(target_df["account"]))
+        )
+
+    # Update account categories
+    def get_nodes_list(path: str) -> List[str]:
+        parts = path.strip("/").split("/")
+        return ["/" + "/".join(parts[:i]) for i in range(1, len(parts) + 1)]
+
+    def account_groups(df: pd.DataFrame) -> Dict[str, str]:
+        if df is None or df.empty:
+            return {}
+
+        df = df.copy()
+        df["nodes"] = [
+            pd.DataFrame({"items": get_nodes_list(path)}) for path in df["group"]
+        ]
+        df = unnest(df, key="nodes")
+        return df.groupby("items")["account"].agg("min").to_dict()
+
+    self._client.update_categories(
+        resource="account",
+        target=account_groups(target),
+        delete=delete,
+        ignore_account_root_nodes=True,
+    )
+    super().mirror_accounts(target, delete)
+
+def _single_account_balance(
+    self, account: int, date: Union[datetime.date, None] = None
+) -> dict:
+    """Calculate the balance of a single account in both account currency
+    and reporting currency.
+
+    Args:
+        account (int): The account number.
+        date (datetime.date, optional): The date for the balance. Defaults to None,
+            in which case the balance on the last day of the current fiscal period is returned.
+
+    Returns:
+        dict: A dictionary with the balance in the account currency and the reporting currency.
+    """
+    account_id = self._client.account_to_id(account)
+    params = {"id": account_id, "date": date}
+    response = self._client.request("GET", "account/balance", params=params)
+    balance = float(response.text)
+
+    account_currency = self._client.account_to_currency(account)
+    if self.reporting_currency == account_currency:
+        reporting_currency_balance = balance
+    else:
+        response = self._client.get(
+            "fiscalperiod/exchangediff.json", params={"date": date}
+        )
+        exchange_diff = pd.DataFrame(response["data"])
+        reporting_currency_balance = exchange_diff.loc[
+            exchange_diff["accountId"] == account_id, "dcBalance"
+        ].item()
+
+    return {account_currency: balance, "reporting_currency": reporting_currency_balance}
+

--- a/cashctrl_ledger/extended_ledger.py
+++ b/cashctrl_ledger/extended_ledger.py
@@ -32,6 +32,20 @@ class ExtendedCashCtrlLedger(CashCtrlLedger):
         super().__init__()
         self.transitory_account = transitory_account
 
+    def clear(self):
+        transitory_account = self._client.account_to_id(
+            self._transitory_account, allow_missing=True
+        )
+        if transitory_account is None:
+            self.accounts.add([{
+                "account": self._transitory_account,
+                "currency": self.reporting_currency,
+                "description": "temp transitory account",
+                "tax_code": None,
+                "group": "/Assets",
+            }])
+        super().clear()
+
     # ----------------------------------------------------------------------
     # Accounts
 
@@ -66,4 +80,12 @@ class ExtendedCashCtrlLedger(CashCtrlLedger):
 
     @transitory_account.setter
     def transitory_account(self, value: int):
+        if value not in set(self._client.list_accounts()["number"]):
+            self.accounts.add([{
+                "account": value,
+                "tax_code": None,
+                "group": "/Assets",
+                "description": "Transitory account",
+                "currency": self.reporting_currency
+            }])
         self._transitory_account = value

--- a/cashctrl_ledger/tax_code.py
+++ b/cashctrl_ledger/tax_code.py
@@ -1,0 +1,98 @@
+   def tax_codes(self) -> pd.DataFrame:
+        """Retrieves tax codes from the remote CashCtrl account and converts to standard
+        pyledger format.
+
+        Returns:
+            pd.DataFrame: A DataFrame with pyledger.TAX_CODE column schema.
+        """
+        tax_rates = self._client.list_tax_rates()
+        accounts = self._client.list_accounts()
+        account_map = accounts.set_index("id")["number"].to_dict()
+        if not tax_rates["accountId"].isin(account_map).all():
+            raise ValueError("Unknown 'accountId' in CashCtrl tax rates.")
+        result = pd.DataFrame(
+            {
+                "id": tax_rates["name"],
+                "description": tax_rates["documentName"],
+                "account": tax_rates["accountId"].map(account_map),
+                "rate": tax_rates["percentage"] / 100,
+                "is_inclusive": ~tax_rates["isGrossCalcType"],
+            }
+        )
+
+        duplicates = set(result.loc[result["id"].duplicated(), "id"])
+        if duplicates:
+            raise ValueError(
+                f"Duplicated tax codes in the remote system: '{', '.join(map(str, duplicates))}'"
+            )
+        return StandaloneLedger.standardize_tax_codes(result)
+
+    def add_tax_code(
+        self,
+        id: str,
+        rate: float,
+        account: str,
+        description: str = "",
+        is_inclusive: bool = True,
+    ):
+        """Adds a new tax code to the CashCtrl account.
+
+        Args:
+            id (str): The tax code to be added.
+            rate (float): The tax rate, must be between 0 and 1.
+            account (str): The account identifier to which the tax is applied.
+            is_inclusive (bool, optional): Determines whether the tax is calculated as 'NET'
+                                        (True, default) or 'GROSS' (False). Defaults to True.
+            description (str, optional): Additional description associated with the tax code.
+                                  Defaults to "".
+        """
+        payload = {
+            "name": id,
+            "percentage": rate * 100,
+            "accountId": self._client.account_to_id(account),
+            "documentName": description,
+            "calcType": "NET" if is_inclusive else "GROSS",
+        }
+        self._client.post("tax/create.json", data=payload)
+        self._client.invalidate_tax_rates_cache()
+
+    def modify_tax_code(
+        self,
+        id: str,
+        rate: float,
+        account: str,
+        description: str = "",
+        is_inclusive: bool = True,
+    ):
+        """Updates an existing tax code in the CashCtrl account with new parameters.
+
+        Args:
+            id (str): The tax code to be updated.
+            rate (float): The tax rate, must be between 0 and 1.
+            account (str): The account identifier to which the tax is applied.
+            is_inclusive (bool, optional): Determines whether the tax is calculated as 'NET'
+                                        (True, default) or 'GROSS' (False). Defaults to True.
+            description (str, optional): Additional description associated with the tax code.
+                                  Defaults to "".
+        """
+        payload = {
+            "id": self._client.tax_code_to_id(id),
+            "percentage": rate * 100,
+            "accountId": self._client.account_to_id(account),
+            "calcType": "NET" if is_inclusive else "GROSS",
+            "name": id,
+            "documentName": description,
+        }
+        self._client.post("tax/update.json", data=payload)
+        self._client.invalidate_tax_rates_cache()
+
+    def delete_tax_codes(self, codes: List[str] = [], allow_missing: bool = False):
+        ids = []
+        for code in codes:
+            id = self._client.tax_code_to_id(code, allow_missing=allow_missing)
+            if id:
+                ids.append(str(id))
+
+        if len(ids):
+            self._client.post("tax/delete.json", {"ids": ", ".join(ids)})
+            self._client.invalidate_tax_rates_cache()

--- a/cashctrl_ledger/tests/test_accounts.py
+++ b/cashctrl_ledger/tests/test_accounts.py
@@ -1,0 +1,195 @@
+"""Unit tests for accounts accessor and mutator methods."""
+
+from io import StringIO
+import pandas as pd
+import pytest
+from pyledger.tests.base_accounts import BaseTestAccounts
+# flake8: noqa: F401
+from base_test import initial_ledger
+from requests.exceptions import RequestException
+
+
+ACCOUNT_CSV = """
+    group,         account, currency, tax_code, description
+    /Balance,         9990,      EUR,         , Test EUR Bank Account
+    /Balance/Node,    9993,      EUR,         , Transitory Account EUR
+"""
+
+LEDGER_CSV = """
+    id,     date, account, contra, currency,     amount, report_amount, description
+    1,  2024-01-21,  9992,   9995,      CHF,     100.00,              , transaction 1
+    2,  2024-02-22,  9991,   9994,      USD,     100.00,         88.88, transaction 2
+    3,  2024-03-23,  9991,       ,      USD,     100.00,         85.55, transaction 3
+    3,  2024-03-23,      ,   9995,      CHF,      85.55,              , transaction 3
+    4,  2024-04-24,  9994,   9991,      USD,     100.00,         77.77, transaction 4
+    5,  2024-05-25,  9992,   9995,      CHF,      10.00,              , transaction 5
+    6,  2024-06-26,  9995,       ,      CHF,      95.55,              , transaction 6
+    6,  2024-06-26,      ,   9991,      USD,     100.00,         95.55, transaction 6
+"""
+LEDGER_ENTRIES = pd.read_csv(StringIO(LEDGER_CSV), skipinitialspace=True)
+ACCOUNTS = pd.read_csv(StringIO(ACCOUNT_CSV), skipinitialspace=True)
+
+
+class TestAccounts(BaseTestAccounts):
+    @pytest.fixture()
+    def ledger(self, initial_ledger):
+        initial_ledger.clear()
+        return initial_ledger
+
+    @pytest.fixture(scope="class")
+    def ledger_with_balance(self, initial_ledger):
+        initial_ledger.restore(accounts=self.ACCOUNTS, ledger=LEDGER_ENTRIES, settings=self.SETTINGS)
+        return initial_ledger
+
+    # TODO: Move this test to the PyLedger package when storing Price history implemented
+    @pytest.mark.parametrize(
+        "account, date, expected",
+        [
+            (9991, "2024-02-21", {"USD": 0.00, "reporting_currency": 0.00}),
+            (9991, "2024-02-22", {"USD": 100.00, "reporting_currency": 88.88}),
+            (9991, "2024-03-23", {"USD": 200.00, "reporting_currency": 174.43}),
+            (9991, "2024-04-24", {"USD": 100.00, "reporting_currency": 96.66}),
+            (9991, "2024-06-26", {"USD": 0.00, "reporting_currency": 1.11}),
+            (9991, None, {"USD": 0.00, "reporting_currency": 1.11}),
+            (9992, "2024-01-20", {"CHF": 0.00, "reporting_currency": 0.00}),
+            (9992, "2024-01-21", {"CHF": 100.00, "reporting_currency": 100.00}),
+            (9992, "2024-05-25", {"CHF": 110.00, "reporting_currency": 110.00}),
+            (9992, None, {"CHF": 110.00, "reporting_currency": 110.00}),
+            (9994, "2024-02-21", {"USD": 0.00, "reporting_currency": 0.00}),
+            (9994, "2024-02-22", {"USD": -100.00, "reporting_currency": -88.88}),
+            (9994, "2024-04-24", {"USD": 0.00, "reporting_currency": -11.11}),
+            (9994, None, {"USD": 0.00, "reporting_currency": -11.11}),
+            (9995, "2024-01-20", {"CHF": 0.00, "reporting_currency": 0.00}),
+            (9995, "2024-01-21", {"CHF": -100.00, "reporting_currency": -100.00}),
+            (9995, "2024-03-23", {"CHF": -185.55, "reporting_currency": -185.55}),
+            (9995, "2024-05-25", {"CHF": -195.55, "reporting_currency": -195.55}),
+            (9995, "2024-06-26", {"CHF": -100.00, "reporting_currency": -100.00}),
+            (9995, None, {"CHF": -100.00, "reporting_currency": -100.00}),
+        ],
+    )
+    def test_account_single_balance(self, ledger_with_balance, account, date, expected):
+        balance = ledger_with_balance._single_account_balance(account=account, date=date)
+        assert balance == expected
+
+    def test_add_already_existed_raise_error(self, ledger):
+        super().test_add_already_existed_raise_error(
+            ledger, error_class=RequestException, error_message="This number is already used"
+        )
+
+    def test_modify_non_existed_raise_error(self, ledger):
+        super().test_modify_non_existed_raise_error(
+            ledger, error_class=ValueError, error_message="No id found for account"
+        )
+    def test_delete_non_existing_account_raise_error(self, ledger):
+        ledger.delete_accounts([1141], allow_missing=True)
+        assert 1141 not in ledger.accounts()["account"].values
+        with pytest.raises(ValueError):
+            ledger.delete_accounts([1141])
+
+    def test_add_account_with_invalid_currency_error(self, ledger):
+        with pytest.raises(ValueError):
+            ledger.add_account(
+                account=1142,
+                currency="",
+                description="test account",
+                tax_code=None,
+                group="/Assets/Anlagevermögen",
+            )
+
+    def test_add_account_with_invalid_tax_raise_error(self, ledger):
+        with pytest.raises(ValueError):
+            ledger.modify_account(
+                account=1143,
+                currency="USD",
+                description="test account",
+                tax_code="Non-Existing Tax Code",
+                group="/Assets/Anlagevermögen",
+            )
+
+    def test_add_account_with_invalid_group_raise_error(self, ledger):
+        with pytest.raises(ValueError):
+            ledger.add_account(
+                account=999999,
+                currency="USD",
+                description="test account",
+                tax_code="MwSt. 2.6%",
+                group="/Assets/Anlagevermögen/ABC",
+            )
+
+    def test_update_non_existing_account_raise_error(self, ledger):
+        with pytest.raises(ValueError):
+            ledger.modify_account(
+                account=1147,
+                currency="CHF",
+                description="test account",
+                tax_code="MwSt. 2.6%",
+                group="/Assets/Anlagevermögen",
+            )
+
+    def test_modify_account_with_invalid_currency_error(self, ledger):
+        with pytest.raises(ValueError):
+            ledger.modify_account(
+                account=1148,
+                currency="not-existing-currency",
+                description="test account",
+                tax_code=None,
+                group="/Assets/Anlagevermögen",
+            )
+
+    def test_modify_account_with_invalid_tax_raise_error(self, ledger):
+        with pytest.raises(ValueError):
+            ledger.modify_account(
+                account=1149,
+                currency="USD",
+                description="test create account",
+                tax_code="Non-Existing Tax Code",
+                group="/Assets/Anlagevermögen",
+            )
+
+    def test_modify_account_with_invalid_group_raise_error(self, ledger):
+        with pytest.raises(ValueError):
+            ledger.modify_account(
+                account=1149,
+                currency="USD",
+                description="test create account",
+                tax_code="MwSt. 2.6%",
+                group="/ABC",
+            )
+
+    def test_mirror_accounts_with_root_category(self, ledger):
+        """This test ensures that root categories remain untouched, and all new accounts categories
+        expected to be created are done so before any existing accounts are mirrored.
+        """
+        ledger.restore(accounts=ACCOUNTS, settings=self.SETTINGS)
+        initial_accounts = ledger.accounts()
+        expected = initial_accounts[~initial_accounts["group"].str.startswith("/Balance")]
+        initial_categories = ledger._client.list_categories("account", include_system=True)
+        categories_dict = initial_categories.set_index("path")["number"].to_dict()
+
+        assert not initial_accounts[initial_accounts["group"].str.startswith("/Balance")].empty, (
+            "There are no remote accounts placed in /Balance node"
+        )
+
+        ledger.mirror_accounts(expected.copy(), delete=True)
+        mirrored_df = ledger.accounts()
+        updated_categories = ledger._client.list_categories("account", include_system=True)
+        updated_categories_dict = updated_categories.set_index("path")["number"].to_dict()
+        difference = set(categories_dict.keys()) - set(updated_categories_dict.keys())
+        initial_sub_nodes = [
+            key for key in difference if key.startswith("/Balance") and key != "/Balance"
+        ]
+
+        assert mirrored_df[mirrored_df["group"].str.startswith("/Balance")].empty, (
+            "Accounts placed in /Balance node were not deleted"
+        )
+        assert len(initial_sub_nodes) > 0, "Sub-nodes were not deleted"
+        assert updated_categories_dict["/Balance"] == categories_dict["/Balance"], (
+            "Root node /Balance was deleted"
+        )
+
+        ledger.mirror_accounts(initial_accounts.copy(), delete=True)
+        mirrored_df = ledger.accounts()
+        updated_categories = ledger._client.list_categories("account", include_system=True)
+        updated_categories_dict = initial_categories.set_index("path")["number"].to_dict()
+        pd.testing.assert_frame_equal(initial_accounts, mirrored_df)
+        assert updated_categories_dict == categories_dict, "Some categories were not restored"

--- a/cashctrl_ledger/tests/test_tax_codes.py
+++ b/cashctrl_ledger/tests/test_tax_codes.py
@@ -1,0 +1,45 @@
+"""Unit tests for vat codes accessor, mutator, and mirror methods."""
+
+import pytest
+import pandas as pd
+from pyledger.tests import BaseTestVatCode
+# flake8: noqa: F401
+from base_test import initial_ledger
+
+
+class TestVatCodes(BaseTestVatCode):
+    @pytest.fixture(scope="class")
+    def ledger(self, initial_ledger):
+        initial_ledger.clear()
+        return initial_ledger
+
+    @pytest.mark.skip(reason="Cashctrl allows creating duplicate VAT codes")
+    def test_create_already_existed_raise_error(self):
+        pass
+
+    def test_update_non_existent_raise_error(self, ledger):
+        super().test_update_non_existent_raise_error(ledger, error_message="No id found for tax code")
+
+    def test_add_vat_with_not_valid_account_raise_error(self, ledger):
+        ledger.delete_accounts([8888], allow_missing=True)
+        assert 8888 not in ledger.account_chart()["account"].values
+        with pytest.raises(ValueError):
+            ledger.add_vat_code(
+                code="TestCode", text="VAT 20%", account=8888, rate=0.02, inclusive=True
+            )
+
+    def test_update_vat_with_not_valid_account_raise_error(self, ledger):
+        ledger.delete_accounts([8888], allow_missing=True)
+        assert 8888 not in ledger.account_chart()["account"].values
+        with pytest.raises(ValueError):
+            ledger.modify_vat_code(
+                code="TestCode", text="VAT 20%", account=8888, rate=0.02, inclusive=True
+            )
+
+    def test_delete_vat_non_existent(self, ledger):
+        ledger.delete_vat_codes(["TestCode"], allow_missing=True)
+        assert "TestCode" not in ledger.vat_codes()["id"].values
+
+    def test_delete_non_existent_vat_raise_error(self, ledger):
+        with pytest.raises(ValueError):
+            ledger.delete_vat_codes(["TestCode"])


### PR DESCRIPTION
Restore former accessors/mutators and base tests for accounts and tax code.
This lays the ground for #83, allowing to better grasp changes to the original code.