### PR TITLE
Implement price history entity

### DIFF
--- a/cashctrl_ledger/extended_ledger.py
+++ b/cashctrl_ledger/extended_ledger.py
@@ -2,7 +2,6 @@
 directly represented in CahCtrl.
 """
 
-from typing import Any
 from .ledger import CashCtrlLedger
 
 
@@ -29,7 +28,7 @@ class ExtendedCashCtrlLedger(CashCtrlLedger):
     # ----------------------------------------------------------------------
     # Constructor
 
-    def __init__(self, transitory_account: int, *args: Any, **kwargs: Any):
+    def __init__(self, transitory_account: int, *args, **kwargs):
         super().__init__(*args, **kwargs)
         self.transitory_account = transitory_account
 

--- a/cashctrl_ledger/extended_ledger.py
+++ b/cashctrl_ledger/extended_ledger.py
@@ -2,6 +2,7 @@
 directly represented in CahCtrl.
 """
 
+from typing import Any
 from .ledger import CashCtrlLedger
 
 
@@ -28,8 +29,8 @@ class ExtendedCashCtrlLedger(CashCtrlLedger):
     # ----------------------------------------------------------------------
     # Constructor
 
-    def __init__(self, transitory_account: int):
-        super().__init__()
+    def __init__(self, transitory_account: int, *args: Any, **kwargs: Any):
+        super().__init__(*args, **kwargs)
         self.transitory_account = transitory_account
 
     def clear(self):

--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -28,7 +28,7 @@ class CashCtrlLedger(LedgerEngine):
 
     def __init__(
         self,
-        client: Union[CachedCashCtrlClient, None] = None,
+        client: CachedCashCtrlClient | None = None,
         price_history_path: Path = Path.cwd() / "price_history.csv"
     ):
         super().__init__()

--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -6,11 +6,13 @@ from typing import Union
 import zipfile
 from cashctrl_api import CachedCashCtrlClient
 import pandas as pd
+from pathlib import Path
 from .tax_code import TaxCode
 from .accounts import Account
 from pyledger import LedgerEngine
 from .constants import SETTINGS_KEYS
-from pyledger.constants import TAX_CODE_SCHEMA, ACCOUNT_SCHEMA
+from pyledger.constants import TAX_CODE_SCHEMA, ACCOUNT_SCHEMA, PRICE_SCHEMA
+from pyledger import CSVAccountingEntity
 
 
 class CashCtrlLedger(LedgerEngine):
@@ -24,12 +26,17 @@ class CashCtrlLedger(LedgerEngine):
     # ----------------------------------------------------------------------
     # Constructor
 
-    def __init__(self, client: Union[CachedCashCtrlClient, None] = None):
+    def __init__(
+        self,
+        client: Union[CachedCashCtrlClient, None] = None,
+        price_history_path: Path = Path.cwd() / "price_history.csv"
+    ):
         super().__init__()
         client = CachedCashCtrlClient() if client is None else client
         self._client = client
         self._tax_codes = TaxCode(client=client, schema=TAX_CODE_SCHEMA)
         self._accounts = Account(client=client, schema=ACCOUNT_SCHEMA)
+        self._price_history = CSVAccountingEntity(schema=PRICE_SCHEMA, path=price_history_path)
 
     # ----------------------------------------------------------------------
     # File operations

--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -46,9 +46,10 @@ class CashCtrlLedger(LedgerEngine):
             archive.writestr('settings.json', json.dumps(self.settings_list()))
             archive.writestr('tax_codes.csv', self.tax_codes.list().to_csv(index=False))
             archive.writestr('accounts.csv', self.accounts.list().to_csv(index=False))
+            archive.writestr('price_history.csv', self.price_history.list().to_csv(index=False))
 
     def restore_from_zip(self, archive_path: str):
-        required_files = {'tax_codes.csv', 'accounts.csv', 'settings.json'}
+        required_files = {'tax_codes.csv', 'accounts.csv', 'settings.json', 'price_history.csv'}
 
         with zipfile.ZipFile(archive_path, 'r') as archive:
             archive_files = set(archive.namelist())
@@ -61,10 +62,12 @@ class CashCtrlLedger(LedgerEngine):
             settings = json.loads(archive.open('settings.json').read().decode('utf-8'))
             accounts = pd.read_csv(archive.open('accounts.csv'))
             tax_codes = pd.read_csv(archive.open('tax_codes.csv'))
+            price_history = pd.read_csv(archive.open('price_history.csv'))
             self.restore(
                 settings=settings,
                 tax_codes=tax_codes,
                 accounts=accounts,
+                price_history=price_history,
             )
 
     def restore(
@@ -72,6 +75,7 @@ class CashCtrlLedger(LedgerEngine):
         settings: dict | None = None,
         tax_codes: pd.DataFrame | None = None,
         accounts: pd.DataFrame | None = None,
+        price_history: pd.DataFrame | None = None,
     ):
         self.clear()
         if accounts is not None:
@@ -82,6 +86,8 @@ class CashCtrlLedger(LedgerEngine):
             self.accounts.mirror(accounts, delete=True)
         if settings is not None:
             self.settings_modify(settings)
+        if price_history is not None:
+            self.price_history.mirror(price_history, delete=True)
         # TODO: Implement logic for other entities
 
     def clear(self):
@@ -92,6 +98,7 @@ class CashCtrlLedger(LedgerEngine):
         self.accounts.mirror(accounts.assign(tax_code=pd.NA))
         self.tax_codes.mirror(None, delete=True)
         self.accounts.mirror(None, delete=True)
+        self.price_history.mirror(None, delete=True)
         # TODO: Implement logic for other entities
 
     # ----------------------------------------------------------------------

--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -228,22 +228,3 @@ class CashCtrlLedger(LedgerEngine):
 
     def precision(self, ticker: str, date: datetime.date = None) -> float:
         return self._precision.get(ticker, 0.01)
-
-    def price(self, currency: str, date: datetime.date = None) -> float:
-        """
-        Retrieves the price (exchange rate) of a given currency in terms
-        of the reporting currency.
-
-        Args:
-            currency (str): The currency code to retrieve the price for.
-            date (datetime.date, optional): The date for which the price is
-                requested. Defaults to None, which retrieves the latest price.
-
-        Returns:
-            float: The exchange rate between the currency and the reporting currency.
-        """
-        return self._client.get_exchange_rate(
-            from_currency=currency,
-            to_currency=self.reporting_currency,
-            date=date
-        )

--- a/cashctrl_ledger/tests/base_test.py
+++ b/cashctrl_ledger/tests/base_test.py
@@ -5,7 +5,11 @@ from cashctrl_ledger import ExtendedCashCtrlLedger
 @pytest.fixture(scope="module")
 def initial_engine(tmp_path_factory):
     tmp_path = tmp_path_factory.mktemp("temp")
-    ledger = ExtendedCashCtrlLedger(transitory_account=9999)
+    ledger = ExtendedCashCtrlLedger(
+        transitory_account=9999,
+        price_history_path=tmp_path / "price_history.csv"
+    )
+
     ledger.dump_to_zip(tmp_path / "ledger.zip")
 
     yield ledger

--- a/cashctrl_ledger/tests/test_price_history.py
+++ b/cashctrl_ledger/tests/test_price_history.py
@@ -10,7 +10,5 @@ class TestPriceHistory(BaseTestPriceHistory):
 
     @pytest.fixture
     def engine(self, initial_engine):
-        # Need to clear price history before tests.
-        # Initial engine keeps one price history file across whole module tests
         initial_engine.price_history.mirror(None, delete=True)
         return initial_engine

--- a/cashctrl_ledger/tests/test_price_history.py
+++ b/cashctrl_ledger/tests/test_price_history.py
@@ -1,0 +1,16 @@
+"""Test suite for price history operations."""
+
+import pytest
+from pyledger.tests import BaseTestPriceHistory
+# flake8: noqa: F401
+from base_test import initial_engine
+
+
+class TestPriceHistory(BaseTestPriceHistory):
+
+    @pytest.fixture
+    def engine(self, initial_engine):
+        # Need to clear price history before tests.
+        # Initial engine keeps one price history file across whole module tests
+        initial_engine.price_history.mirror(None, delete=True)
+        return initial_engine


### PR DESCRIPTION
This PR aims to implement the Price History entity.  

As agreed, we mimic the behavior from `TextLedger`, since in `CashCtrlLedger`, it’s not possible to implement price history directly (exchange rates are sourced from Swiss authorities and cannot be added, deleted, or updated).  

**Note:** Tests will fail until https://github.com/macxred/pyledger/pull/72 is merged.  

Shout if you disagree with the changes!