### PR TITLE
Implement assets entity

### DIFF
--- a/cashctrl_ledger/tests/test_assets.py
+++ b/cashctrl_ledger/tests/test_assets.py
@@ -1,0 +1,14 @@
+"""Test suite for assets operations."""
+
+import pytest
+from pyledger.tests import BaseTestAssets
+# flake8: noqa: F401
+from base_test import initial_engine
+
+
+class TestAssets(BaseTestAssets):
+
+    @pytest.fixture
+    def engine(self, initial_engine):
+        initial_engine.assets.mirror(None, delete=True)
+        return initial_engine


### PR DESCRIPTION
This PR aims to implement the Assets entity.

As agreed, we mimic the behavior from TextLedger, since in CashCtrlLedger, it’s not possible to implement assets directly (Incompatibility of entities).

Note: Tests will fail until https://github.com/macxred/pyledger/pull/75 is merged.

Shout if you disagree with the changes!