### PR TITLE
Implement fiscal periods

### DIFF
--- a/cashctrl_ledger/constants.py
+++ b/cashctrl_ledger/constants.py
@@ -1,5 +1,9 @@
 """This module contains constants used throughout the application."""
 
+import pandas as pd
+from io import StringIO
+
+
 JOURNAL_ITEM_COLUMNS = {
     "accountId": "int",
     "description": "string[python]",
@@ -23,3 +27,13 @@ SETTINGS_KEYS = [
     "DEFAULT_EXCHANGE_DIFF_ACCOUNT_ID",
     "DEFAULT_CREDITOR_ACCOUNT_ID"
 ]
+
+
+FISCAL_PERIOD_SCHEMA_CSV = """
+    column,              dtype,   mandatory,       id
+        id,              Int64,        True,     True
+     start,     datetime64[ns],        True,     False
+       end,     datetime64[ns],        True,     False
+      name,     string[python],        True,      False
+"""
+FISCAL_PERIOD_SCHEMA = pd.read_csv(StringIO(FISCAL_PERIOD_SCHEMA_CSV), skipinitialspace=True)

--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -439,7 +439,7 @@ class CashCtrlLedger(LedgerEngine):
     def _ledger_add(self, data: pd.DataFrame) -> str:
         ids = []
         incoming = self.ledger.standardize(data)
-        self.ensure_fiscal_periods(data["date"])
+        self.ensure_fiscal_periods_exist(incoming["date"].min(), incoming["date"].max())
         for id in incoming["id"].unique():
             entry = incoming.query("id == @id")
             payload = self._map_ledger_entry(entry)
@@ -450,6 +450,7 @@ class CashCtrlLedger(LedgerEngine):
 
     def _ledger_modify(self, data: pd.DataFrame):
         incoming = self.ledger.standardize(data)
+        self.ensure_fiscal_periods_exist(incoming["date"].min(), incoming["date"].max())
         for id in incoming["id"].unique():
             entry = incoming.query("id == @id")
             payload = self._map_ledger_entry(entry)

--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -373,12 +373,16 @@ class CashCtrlLedger(LedgerEngine):
         fiscal_periods = enforce_schema(pd.DataFrame(fiscal_periods), FISCAL_PERIOD_SCHEMA)
         fp = fiscal_periods.sort_values("start").reset_index(drop=True)
 
+        # Normalize start and end dates to reset time to 00:00:00
+        fp["start"] = fp["start"].dt.normalize()
+        fp["end"] = fp["end"].dt.normalize()
+
         # Calculate the gap between consecutive periods (next start - current end)
         consecutive_gap = fp["start"].dt.date.shift(-1) - fp["end"].dt.date
         # Exclude the last period as it has no successor
         consecutive_gap = consecutive_gap[:-1]
         if not (consecutive_gap == pd.Timedelta(days=1)).all():
-            raise Exception("Gaps between fiscal periods.")
+            raise ValueError("Gaps between fiscal periods.")
 
         return fp
 

--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -19,7 +19,7 @@ from pyledger.constants import (
     LEDGER_SCHEMA,
     ASSETS_SCHEMA
 )
-from .constants import JOURNAL_ITEM_COLUMNS, SETTINGS_KEYS
+from .constants import FISCAL_PERIOD_SCHEMA, JOURNAL_ITEM_COLUMNS, SETTINGS_KEYS
 from consistent_df import unnest, enforce_dtypes, enforce_schema
 
 
@@ -357,9 +357,85 @@ class CashCtrlLedger(LedgerEngine):
         """Not implemented yet."""
         raise NotImplementedError
 
-    def _ledger_add(self, data: pd.DataFrame) -> list[str]:
+    def fiscal_period_list(self) -> pd.DataFrame:
+        """Retrieve fiscal periods.
+
+        Retrieve all fiscal periods and checks that each consecutive period
+        starts exactly one day after the previous one ends.
+
+        Returns:
+            pd.DataFrame: A DataFrame of fiscal periods adhering to the FISCAL_PERIOD_SCHEMA.
+
+        Raises:
+            Exception: If any gap is detected between consecutive fiscal periods.
+        """
+        fiscal_periods = self._client.get("fiscalperiod/list.json")["data"]
+        fiscal_periods = enforce_schema(pd.DataFrame(fiscal_periods), FISCAL_PERIOD_SCHEMA)
+        fp = fiscal_periods.sort_values("start").reset_index(drop=True)
+
+        # Calculate the gap between consecutive periods (next start - current end)
+        consecutive_gap = fp["start"].dt.date.shift(-1) - fp["end"].dt.date
+        # Exclude the last period as it has no successor
+        consecutive_gap = consecutive_gap[:-1]
+        if not (consecutive_gap == pd.Timedelta(days=1)).all():
+            raise Exception("Gaps between fiscal periods.")
+
+        return fp
+
+    def fiscal_period_add(self, start: datetime.date, end: datetime.date, name: str):
+        """Add a new fiscal period.
+
+        Args:
+            start (datetime.date): Start date of the fiscal period.
+            end (datetime.date): End date of the fiscal period.
+            name (str): Name of the fiscal period.
+        """
+        data = {
+            "isCustom": True,
+            "start": start.strftime("%Y-%m-%d"),
+            "end": end.strftime("%Y-%m-%d"),
+            "name": name
+        }
+        self._client.post("fiscalperiod/create.json", data=data)
+
+    def ensure_fiscal_periods_exist(self, start: datetime.date, end: datetime.date):
+        """
+        Ensure fiscal periods exist for the given date range.
+        If any part of the range is not covered by existing fiscal periods,
+        create new periods to fill in the gaps.
+
+        Args:
+            start (datetime.date): Start of the date range to ensure coverage for.
+            end (datetime.date): End of the date range to ensure coverage for.
+        """
+        start = pd.to_datetime(start)
+        end = pd.to_datetime(end)
+        fiscal_periods = self.fiscal_period_list()
+
+        # Extend fiscal periods backward if needed
+        while start < fiscal_periods["start"].min():
+            earliest_start = fiscal_periods["start"].min()
+            # The new fiscal period will be one year before the earliest start
+            new_end = earliest_start - pd.Timedelta(days=1)
+            new_start = earliest_start - pd.DateOffset(years=1)
+            new_name = str(new_start.year)
+            self.fiscal_period_add(start=new_start.date(), end=new_end.date(), name=new_name)
+            fiscal_periods = self.fiscal_period_list()
+
+        # Extend fiscal periods forward if needed
+        while end > fiscal_periods["end"].max():
+            latest_end = fiscal_periods["end"].max()
+            # The new fiscal period will be one year after the latest end
+            new_start = latest_end + pd.Timedelta(days=1)
+            new_end = latest_end + pd.DateOffset(years=1)
+            new_name = str(new_start.year)
+            self.fiscal_period_add(start=new_start.date(), end=new_end.date(), name=new_name)
+            fiscal_periods = self.fiscal_period_list()
+
+    def _ledger_add(self, data: pd.DataFrame) -> str:
         ids = []
         incoming = self.ledger.standardize(data)
+        self.ensure_fiscal_periods(data["date"])
         for id in incoming["id"].unique():
             entry = incoming.query("id == @id")
             payload = self._map_ledger_entry(entry)

--- a/cashctrl_ledger/tests/test_fiscal_periods.py
+++ b/cashctrl_ledger/tests/test_fiscal_periods.py
@@ -1,8 +1,7 @@
 """Unit tests for fiscal periods operations."""
 
-from io import StringIO
-from cashctrl_ledger import CashCtrlLedger
 import pandas as pd
+from cashctrl_ledger import CashCtrlLedger
 import pytest
 
 
@@ -21,10 +20,43 @@ def engine():
     created_ids = set(new_ids) - set(initial_ids)
     if len(created_ids):
         ids = ",".join([str(id) for id in created_ids])
-        breakpoint()
         cashctrl._client.post("fiscalperiod/delete.json", params={"ids": ids})
 
 def test_fiscal_period_exist(engine):
-    fp = engine.fiscal_period_list()
+    fiscal_periods = engine.fiscal_period_list()
+    earliest_start = fiscal_periods["start"].min()
+    latest_end = fiscal_periods["end"].max()
 
-    engine.ensure_fiscal_periods_exist('2022-01-01', '2028-12-31')
+    # Extend 3 years in the past and future
+    past_extension = earliest_start - pd.DateOffset(years=3)
+    future_extension = latest_end + pd.DateOffset(years=3)
+    engine.ensure_fiscal_periods_exist(start=past_extension.date(), end=future_extension.date())
+    updated_fiscal_periods = engine.fiscal_period_list()
+
+    assert len(updated_fiscal_periods) - len(fiscal_periods) == 6, (
+        "Should create 6 new fiscal periods"
+    )
+
+    # Initialize the first expected start and end dates
+    first_start = past_extension
+    first_end = (pd.Timestamp(past_extension.year, 12, 31))
+
+    # Loop over all fiscal periods and validate start and end dates
+    for i, row in updated_fiscal_periods.iterrows():
+        expected_start = first_start + pd.DateOffset(years=i)
+        expected_end = first_end + pd.DateOffset(years=i)
+        assert row["start"] == expected_start, (
+            f"Fiscal period start date {row["start"]} does not match expected {expected_start}"
+        )
+        assert row["end"] == expected_end, (
+            f"Fiscal period end date {row["end"]} does not match expected {expected_end}"
+        )
+
+def test_fiscal_period_list_raise_error_with_gap(engine):
+    fiscal_periods = engine.fiscal_period_list()
+    latest_end = fiscal_periods["end"].max()
+    new_start = latest_end + pd.DateOffset(years=1)
+    new_end = latest_end + pd.DateOffset(years=2)
+    engine.fiscal_period_add(start=new_start, end=new_end, name="test_fiscal_period")
+    with pytest.raises(ValueError, match="Gaps between fiscal periods."):
+        engine.fiscal_period_list()

--- a/cashctrl_ledger/tests/test_fiscal_periods.py
+++ b/cashctrl_ledger/tests/test_fiscal_periods.py
@@ -1,11 +1,11 @@
-"""Unit tests for fiscal periods operations."""
+"""Unit tests for fiscal period operations."""
 
 import pandas as pd
 from cashctrl_ledger import CashCtrlLedger
 import pytest
 
 
-@pytest.fixture()
+@pytest.fixture
 def engine():
     cashctrl = CashCtrlLedger()
     # Retrieve initial fiscal periods ids
@@ -22,7 +22,8 @@ def engine():
         ids = ",".join([str(id) for id in created_ids])
         cashctrl._client.post("fiscalperiod/delete.json", params={"ids": ids})
 
-def test_fiscal_period_exist(engine):
+
+def test_ensure_fiscal_periods_exist(engine):
     fiscal_periods = engine.fiscal_period_list()
     earliest_start = fiscal_periods["start"].min()
     latest_end = fiscal_periods["end"].max()
@@ -34,14 +35,12 @@ def test_fiscal_period_exist(engine):
     updated_fiscal_periods = engine.fiscal_period_list()
 
     assert len(updated_fiscal_periods) - len(fiscal_periods) == 6, (
-        "Should create 6 new fiscal periods"
+        "6 new fiscal periods should be created."
     )
 
-    # Initialize the first expected start and end dates
     first_start = past_extension
     first_end = (pd.Timestamp(past_extension.year, 12, 31))
-
-    # Loop over all fiscal periods and validate start and end dates
+    # Validate start and end dates for created periods
     for i, row in updated_fiscal_periods.iterrows():
         expected_start = first_start + pd.DateOffset(years=i)
         expected_end = first_end + pd.DateOffset(years=i)
@@ -52,11 +51,15 @@ def test_fiscal_period_exist(engine):
             f"Fiscal period end date {row["end"]} does not match expected {expected_end}"
         )
 
-def test_fiscal_period_list_raise_error_with_gap(engine):
+
+def test_fiscal_period_list_raises_error_on_gap_between_fiscal_periods(engine):
     fiscal_periods = engine.fiscal_period_list()
     latest_end = fiscal_periods["end"].max()
-    new_start = latest_end + pd.DateOffset(years=1)
-    new_end = latest_end + pd.DateOffset(years=2)
-    engine.fiscal_period_add(start=new_start, end=new_end, name="test_fiscal_period")
+
+    # Add a fiscal period with a gap
+    gap_start = latest_end + pd.DateOffset(years=1)
+    gap_end = gap_start + pd.DateOffset(years=1)
+    engine.fiscal_period_add(start=gap_start.date(), end=gap_end.date(), name="Test Fiscal Period")
+
     with pytest.raises(ValueError, match="Gaps between fiscal periods."):
         engine.fiscal_period_list()

--- a/cashctrl_ledger/tests/test_fiscal_periods.py
+++ b/cashctrl_ledger/tests/test_fiscal_periods.py
@@ -1,0 +1,30 @@
+"""Unit tests for fiscal periods operations."""
+
+from io import StringIO
+from cashctrl_ledger import CashCtrlLedger
+import pandas as pd
+import pytest
+
+
+@pytest.fixture()
+def engine():
+    cashctrl = CashCtrlLedger()
+    # Retrieve initial fiscal periods ids
+    fiscal_periods = cashctrl._client.get("fiscalperiod/list.json")['data']
+    initial_ids = [fp["id"] for fp in fiscal_periods]
+
+    yield cashctrl
+
+    # Delete any created fiscal period
+    fiscal_periods = cashctrl._client.get("fiscalperiod/list.json")['data']
+    new_ids = [fp["id"] for fp in fiscal_periods]
+    created_ids = set(new_ids) - set(initial_ids)
+    if len(created_ids):
+        ids = ",".join([str(id) for id in created_ids])
+        breakpoint()
+        cashctrl._client.post("fiscalperiod/delete.json", params={"ids": ids})
+
+def test_fiscal_period_exist(engine):
+    fp = engine.fiscal_period_list()
+
+    engine.ensure_fiscal_periods_exist('2022-01-01', '2028-12-31')

--- a/cashctrl_ledger/tests/test_fiscal_periods.py
+++ b/cashctrl_ledger/tests/test_fiscal_periods.py
@@ -14,6 +14,9 @@ def engine():
 
     yield cashctrl
 
+    # Delete any created ledger entries
+    cashctrl.ledger.mirror(pd.DataFrame({}), delete=True)
+
     # Delete any created fiscal period
     fiscal_periods = cashctrl._client.get("fiscalperiod/list.json")['data']
     new_ids = [fp["id"] for fp in fiscal_periods]
@@ -63,3 +66,32 @@ def test_fiscal_period_list_raises_error_on_gap_between_fiscal_periods(engine):
 
     with pytest.raises(ValueError, match="Gaps between fiscal periods."):
         engine.fiscal_period_list()
+
+
+def test_add_and_modify_ledger_entry_creates_missing_fiscal_period(engine):
+    fiscal_periods = engine.fiscal_period_list()
+    latest_end = fiscal_periods["end"].max()
+
+    # Add ledger entry with a date outside existing fiscal periods
+    date = latest_end + pd.DateOffset(years=1)
+    entry = pd.DataFrame([{
+        "date": date, "account": 1000, "contra": 2000, "currency": "CHF",
+        "amount": 100, "description": "test entry",
+    }])
+    id = engine.ledger.add(entry)
+
+    updated_fiscal_periods = engine.fiscal_period_list()
+    assert len(updated_fiscal_periods) > len(fiscal_periods), (
+        "New fiscal period should be created."
+    )
+
+    # Modify ledger entry with a date outside existing fiscal periods
+    fiscal_periods = updated_fiscal_periods
+    entry.loc[:, "id"] = id
+    entry.loc[:, "date"] = date + pd.DateOffset(years=1)
+    engine.ledger.modify(entry)
+
+    updated_fiscal_periods = engine.fiscal_period_list()
+    assert len(updated_fiscal_periods) > len(fiscal_periods), (
+        "New fiscal period should be created."
+    )


### PR DESCRIPTION
This PR adds a mechanism to create fiscal periods for a given date range and integrates it into the `ledger.add` and `ledger.modify` methods to ensure required fiscal periods exist when creating or modifying ledger entries.