### PR TITLE
Sanitize account categories

### DIFF
--- a/cashctrl_ledger/accounts.py
+++ b/cashctrl_ledger/accounts.py
@@ -22,6 +22,13 @@ class Account(CashCtrlAccountingEntity):
 
     def add(self, data: pd.DataFrame):
         incoming = self.standardize(pd.DataFrame(data))
+
+        # Update account categories
+        self._client.update_categories(
+            resource="account", target=self._account_groups(incoming),
+            delete=False, ignore_account_root_nodes=True,
+        )
+
         for _, row in incoming.iterrows():
             payload = {
                 "number": row["account"],
@@ -41,6 +48,13 @@ class Account(CashCtrlAccountingEntity):
         reduced_schema = self._schema.query("column in @cols")
         incoming = enforce_schema(data, reduced_schema, keep_extra_columns=True)
         current = self.list()
+
+        # Update account categories
+        if "group" in cols:
+            self._client.update_categories(
+                resource="account", target=self._account_groups(incoming),
+                delete=False, ignore_account_root_nodes=True,
+            )
 
         for _, row in incoming.iterrows():
             existing = current.query("account == @row['account']")

--- a/cashctrl_ledger/constants.py
+++ b/cashctrl_ledger/constants.py
@@ -39,4 +39,4 @@ FISCAL_PERIOD_SCHEMA_CSV = """
 FISCAL_PERIOD_SCHEMA = pd.read_csv(StringIO(FISCAL_PERIOD_SCHEMA_CSV), skipinitialspace=True)
 
 
-ROOT_ACCOUNT_NODES = ["Assets", "Balance", "Expense", "Liabilities", "Revenue"]
+ACCOUNT_ROOT_CATEGORIES = ["Assets", "Balance", "Expense", "Liabilities", "Revenue"]

--- a/cashctrl_ledger/constants.py
+++ b/cashctrl_ledger/constants.py
@@ -37,3 +37,6 @@ FISCAL_PERIOD_SCHEMA_CSV = """
       name,     string[python],        True,      False
 """
 FISCAL_PERIOD_SCHEMA = pd.read_csv(StringIO(FISCAL_PERIOD_SCHEMA_CSV), skipinitialspace=True)
+
+
+DEFAULT_ACCOUNT_GROUPS = ['/Assets', '/Balance', '/Expense', '/Liabilities', '/Revenue']

--- a/cashctrl_ledger/constants.py
+++ b/cashctrl_ledger/constants.py
@@ -39,4 +39,4 @@ FISCAL_PERIOD_SCHEMA_CSV = """
 FISCAL_PERIOD_SCHEMA = pd.read_csv(StringIO(FISCAL_PERIOD_SCHEMA_CSV), skipinitialspace=True)
 
 
-DEFAULT_ACCOUNT_GROUPS = ['/Assets', '/Balance', '/Expense', '/Liabilities', '/Revenue']
+ROOT_ACCOUNT_NODES = ["Assets", "Balance", "Expense", "Liabilities", "Revenue"]

--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -20,7 +20,7 @@ from pyledger.constants import (
     ASSETS_SCHEMA
 )
 from .constants import (
-    ROOT_ACCOUNT_NODES,
+    ACCOUNT_ROOT_CATEGORIES,
     FISCAL_PERIOD_SCHEMA,
     JOURNAL_ITEM_COLUMNS,
     SETTINGS_KEYS
@@ -204,7 +204,11 @@ class CashCtrlLedger(LedgerEngine):
     # Accounts
 
     def sanitize_account_groups(self, groups: pd.Series) -> pd.Series:
-        """Ensure account group paths are sanitized with a leading slash and a valid root node.
+        """Ensure account groups start with a leading slash and a valid root node.
+
+        Account categories in CashCtrl must be assigned to one of the pre-defined root nodes.
+        Additional root categories are not allowed, and the pre-defined root categories
+        cannot be deleted.
 
         Args:
             groups (pd.Series): A pandas Series containing account group paths.
@@ -212,11 +216,10 @@ class CashCtrlLedger(LedgerEngine):
         Returns:
             pd.Series: Sanitized account group series.
         """
-        # Remove leading slashes
         groups = groups.str.replace(r'^/', '', regex=True)
         first_nodes = groups.str.replace(r'/.*', '', regex=True)
         first_nodes = first_nodes.apply(
-            lambda g: get_close_matches(g, ROOT_ACCOUNT_NODES, cutoff=0)[0]
+            lambda g: get_close_matches(g, ACCOUNT_ROOT_CATEGORIES, cutoff=0)[0]
         )
         groups = groups.where(
             groups.isna(),

--- a/cashctrl_ledger/tests/test_accounts.py
+++ b/cashctrl_ledger/tests/test_accounts.py
@@ -27,11 +27,6 @@ class TestAccounts(BaseTestAccounts):
         return initial_engine
 
     def test_account_accessor_mutators(self, restored_engine):
-        # TODO: some accounts can not be created via add() method since they
-        # are contain groups that do not exist.
-        # This functionality only works when use mirror() method - then categories are created
-        # Hack: Keep only root nodes
-        self.ACCOUNTS['group'] = self.ACCOUNTS['group'].str.split('/').str[1]
         self.ACCOUNTS = restored_engine.sanitize_accounts(self.ACCOUNTS)
         super().test_account_accessor_mutators(restored_engine, ignore_row_order=True)
 

--- a/cashctrl_ledger/tests/test_accounts.py
+++ b/cashctrl_ledger/tests/test_accounts.py
@@ -9,6 +9,7 @@ from base_test import initial_engine
 from requests.exceptions import RequestException
 from consistent_df import assert_frame_equal
 from cashctrl_ledger.constants import ROOT_ACCOUNT_NODES
+from cashctrl_ledger import CashCtrlLedger
 
 
 class TestAccounts(BaseTestAccounts):
@@ -211,10 +212,10 @@ class TestAccounts(BaseTestAccounts):
         ]
     )
 
-    def test_sanitize_account_groups(self, engine, input_groups, expected_groups):
+    def test_sanitize_account_groups(self, input_groups, expected_groups):
+        engine = CashCtrlLedger()
         input_series = pd.Series(input_groups, dtype="string[python]")
         expected_series = pd.Series(expected_groups, dtype="string[python]")
-
         output_series = engine.sanitize_account_groups(input_series)
         assert output_series.equals(expected_series), (
             f"Expected {expected_series.tolist()} but got {output_series.tolist()}"

--- a/cashctrl_ledger/tests/test_accounts.py
+++ b/cashctrl_ledger/tests/test_accounts.py
@@ -8,7 +8,7 @@ from pyledger.tests import BaseTestAccounts
 from base_test import initial_engine
 from requests.exceptions import RequestException
 from consistent_df import assert_frame_equal
-from cashctrl_ledger.constants import ROOT_ACCOUNT_NODES
+from cashctrl_ledger.constants import ACCOUNT_ROOT_CATEGORIES
 from cashctrl_ledger import CashCtrlLedger
 
 
@@ -172,7 +172,7 @@ class TestAccounts(BaseTestAccounts):
         categories = engine._client.list_categories("account", include_system=True)
         categories = categories["path"].to_list()
         assert accounts.empty, "Mirror empty accounts should erase all of them"
-        root_categories = ["/" + category for category in ROOT_ACCOUNT_NODES]
+        root_categories = ["/" + category for category in ACCOUNT_ROOT_CATEGORIES]
         assert set(root_categories) == set(categories), (
             "Mirroring empty state should leave only root categories"
         )

--- a/cashctrl_ledger/tests/test_tax_codes.py
+++ b/cashctrl_ledger/tests/test_tax_codes.py
@@ -8,10 +8,6 @@ from base_test import initial_engine
 
 
 class TestTaxCodes(BaseTestTaxCodes):
-    ACCOUNTS = BaseTestTaxCodes.ACCOUNTS.copy()
-    # Set the default root node for CashCtrl. In CashCtrl it is not possible to create root nodes
-    ACCOUNTS.loc[:, "group"] = "/Assets"
-
     TAX_CODES = BaseTestTaxCodes.TAX_CODES.copy()
     # In CashCtrl it is not possible to create TAX CODE without specified account
     account = TAX_CODES.query("id == 'IN_STD'")["account"].values[0]
@@ -20,6 +16,7 @@ class TestTaxCodes(BaseTestTaxCodes):
 
     @pytest.fixture(scope="class")
     def engine(self, initial_engine):
+        self.ACCOUNTS = initial_engine.sanitize_accounts(self.ACCOUNTS)
         initial_engine.clear()
         return initial_engine
 


### PR DESCRIPTION
This PR aims to ensure that account group paths are sanitized with a leading slash and include a valid root node, conforming to the valid CashCtrl format.