### PR TITLE
Use report_amount() method from parent class

### DIFF
--- a/cashctrl_ledger/extended_ledger.py
+++ b/cashctrl_ledger/extended_ledger.py
@@ -2,8 +2,6 @@
 directly represented in CahCtrl.
 """
 
-import datetime
-from typing import List
 import numpy as np
 import pandas as pd
 from .ledger import CashCtrlLedger
@@ -116,24 +114,9 @@ class ExtendedCashCtrlLedger(CashCtrlLedger):
         """
         ledger = self.ledger.standardize(ledger)
 
-        # TODO: move this method to LedgerEngine class
-        def _reporting_currency_amount(amount: List[float], currency: List[str],
-                                       date: List[datetime.date]) -> List[float]:
-            reporting_currency = self.reporting_currency
-            if not (len(amount) == len(currency) == len(date)):
-                raise ValueError(
-                    "Vectors 'amount', 'currency', and 'date' must have the same length."
-                )
-            result = [
-                self.round_to_precision(
-                    a * self.price(t, date=d, currency=reporting_currency)[1],
-                    reporting_currency, date=d)
-                for a, t, d in zip(amount, currency, date)]
-            return result
-
         # Insert missing base currency amounts
         mask = ledger['report_amount'].isna()
-        ledger.loc[mask, 'report_amount'] = _reporting_currency_amount(
+        ledger.loc[mask, 'report_amount'] = self.report_amount(
             amount=ledger.loc[mask, 'amount'],
             currency=ledger.loc[mask, 'currency'],
             date=ledger.loc[mask, 'date']


### PR DESCRIPTION
This PR goal is to remove hardcoded `_reporting_currency_amount()` method and use it from the parent `LedgerEngine` class