### PR TITLE
Update tests for pyledger serialize_ledger reporting currency fix

### DIFF
--- a/cashctrl_ledger/tests/base_test.py
+++ b/cashctrl_ledger/tests/base_test.py
@@ -1,7 +1,5 @@
 """Definition of CashCtrl base class for testing."""
 
-from io import StringIO
-import pandas as pd
 import pytest
 from cashctrl_ledger import ExtendedCashCtrlLedger
 from pyledger.tests import BaseTest
@@ -15,49 +13,14 @@ class BaseTestCashCtrl(BaseTest):
     default_account = TAX_CODES.query("id == 'IN_STD'")["account"].values[0]
     TAX_CODES.loc[TAX_CODES["account"].isna(), "account"] = default_account
 
-    # In CashCtrl, the account balance dictionary includes only the total amount in the account’s
-    # denominated currency, even when transactions involve multiple currencies. In contrast,
-    # PyLedger provides a granular breakdown of balances by all transaction currencies.
-    # For example, PyLedger might report:
-    #     {'EUR': -380.96, 'USD': -200.0}
-    # for a USD-denominated account with mixed-currency transactions, whereas CashCtrl would report:
-    #     {'USD': -607.94}
-    # as it converts and aggregates all amounts into the denominated currency.
-    # Because of this discrepancy, we must override the base test data with CashCtrl-style expected
-    # balances to ensure compatibility in test assertions.
-    # We also exclude entries with profit centers, as CashCtrl doesn’t support filtering balances
-    # by them.
-    override_entries_dates = ["2024-12-31", "2024"]
-    filtered_balances = BaseTest.EXPECTED_BALANCES.query("profit_center.isna()")
-    filtered_balances = filtered_balances.query("period not in @ override_entries_dates")
-    # flake8: noqa: E501
-    EXPECTED_BALANCES_CSV = """
-        period,       account,            profit_center, report_balance,   balance
-        2024-12-31,      4001,                         ,       -1198.26,   "{EUR: -1119.04}"
-        2024,       1000:1999,                         ,    12719310.10,   "{USD: 1076772.64, EUR: 10026667.1, JPY: 54345678.0, CHF: 14285714.3}"
-        2024-08,    1000:1999,                         ,         -700.0,   "{USD: -700.0}"
-        2024-12-31,      2979,                         ,   -12719202.16,   "{USD: -12719202.16}"
-        2024-12-31,      9200,                         ,    12719202.16,   "{USD: 12719202.16}"
-        2024-12-31,      2970,                         ,           0.00,   "{USD: 0.00}"
-        2024-12-31,      1170,                         ,           0.00,   "{USD: 0.00}"
-        2024-12-31,      1171,                         ,           0.00,   "{USD: 0.00}"
-        2024-12-31,      1175,                         ,         200.00,   "{USD: 200.00}"
-        2024-12-31,      2200,                         ,        -807.94,   "{USD: -807.94}"
-        2024-12-31, 3000:9999,                         ,          -0.01,   "{USD: 1198.25, EUR: -1119.04}"
-    """
-    EXPECTED_BALANCES = pd.read_csv(StringIO(EXPECTED_BALANCES_CSV), skipinitialspace=True)
-    EXPECTED_BALANCES["profit_center"] = EXPECTED_BALANCES["profit_center"].apply(BaseTest.parse_profit_center)
-    EXPECTED_BALANCES["balance"] = BaseTest.parse_balance_series(EXPECTED_BALANCES["balance"])
-    EXPECTED_BALANCES = pd.concat([filtered_balances, EXPECTED_BALANCES])
-    balances = pd.Series([
-        "{USD: 1076311.79}", "{USD: -100.0, EUR: -20.0}", "{EUR: 10026687.1}",
-        "{JPY: 54345678.0}", "{CHF: 14285714.3}", "{}", "{USD: 360.85}", "{USD: 700.0}",
-        "{}", "{USD: -607.94}", "{}", "{}", "{USD: -11098332.82}", "{USD: -1000.0}",
-        "{EUR: -1119.04}", "{USD: 3502.64}", "{USD: -1622168.17}", "{USD: -5.55}", "{}"
-    ])
-    EXPECTED_AGGREGATED_BALANCES = BaseTest.EXPECTED_AGGREGATED_BALANCES
-    EXPECTED_AGGREGATED_BALANCES["balance"] = BaseTest.parse_balance_series(balances)
-    # flake8: enable
+    # CashCtrl doesn't support filtering balances by profit centers, so we exclude those entries.
+    # After the serialize_ledger fix for reporting currency accounts, CashCtrl and PyLedger
+    # now return the same balance values, except for minor rounding differences.
+    EXPECTED_BALANCES = BaseTest.EXPECTED_BALANCES.query("profit_center.isna()").copy()
+    # Override: CashCtrl reports -0.01 due to rounding, PyLedger reports 0.0
+    mask = ((EXPECTED_BALANCES["period"] == "2024-12-31")
+            & (EXPECTED_BALANCES["account"] == "3000:9999"))
+    EXPECTED_BALANCES.loc[mask, "report_balance"] = -0.01
 
     @pytest.fixture(scope="module")
     def initial_engine(self, tmp_path_factory):
@@ -65,7 +28,7 @@ class BaseTestCashCtrl(BaseTest):
         engine = ExtendedCashCtrlLedger(
             transitory_account=9999,
             root=tmp_path,
-            price_history_path = "settings/price_history.csv",
+            price_history_path="settings/price_history.csv",
             assets_path="settings/assets.csv",
         )
         engine.dump_to_zip(tmp_path / "ledger.zip")

--- a/cashctrl_ledger/tests/test_accounts.py
+++ b/cashctrl_ledger/tests/test_accounts.py
@@ -283,8 +283,10 @@ class TestAccounts(BaseTestCashCtrl, BaseTestAccounts):
         account_balances = engine.individual_account_balances(period="2024", accounts="1000:9999")
         actual = engine.aggregate_account_balances(account_balances, n=2)
         actual = actual.query("description != 'Transitory account'")
+        actual["balance"] = actual["balance"].apply(drop_zero_balances)
         expected = enforce_schema(self.EXPECTED_AGGREGATED_BALANCES, AGGREGATED_BALANCE_SCHEMA)
         expected["group"] = engine.sanitize_account_groups(expected["group"])
+        expected["balance"] = expected["balance"].apply(drop_zero_balances)
         assert_frame_equal(actual, expected, ignore_index=True)
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
### Summary
- Simplify `EXPECTED_BALANCES` - CashCtrl and PyLedger now return matching balance values after macxred/pyledger#315
- Keep minor 0.01 rounding override for `3000:9999` account
- Add `drop_zero_balances` to `test_aggregate_account_balances` for consistent empty balance dict comparison
