### PR TITLE
Fix class attribute assignment in test fixture

### DIFF
--- a/cashctrl_ledger/tests/base_test.py
+++ b/cashctrl_ledger/tests/base_test.py
@@ -32,7 +32,9 @@ class BaseTestCashCtrl(BaseTest):
             assets_path="settings/assets.csv",
         )
         engine.dump_to_zip(tmp_path / "ledger.zip")
-        self.ACCOUNTS = engine.sanitize_accounts(df=self.ACCOUNTS, tax_codes=self.TAX_CODES)
+        BaseTestCashCtrl.ACCOUNTS = engine.sanitize_accounts(
+            df=self.ACCOUNTS, tax_codes=self.TAX_CODES,
+        )
 
         yield engine
 


### PR DESCRIPTION
## Summary
- Use `BaseTestCashCtrl.ACCOUNTS` instead of `self.ACCOUNTS` in `initial_engine` fixture to set the class attribute directly, avoiding instance attribute shadowing.

## Test plan
- [x] All 102 tests pass, 5 skipped (live CashCtrl API on alex49)
- [x] Restore script runs clean twice