### PR TITLE
Migrate cashctrl_ledger to polars

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -45,8 +45,18 @@ jobs:
         with:
           python-version: "3.x"
 
+      - name: Determine pyledger branch
+        id: pyledger-branch
+        run: |
+          BRANCH="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
+          if [[ "$BRANCH" == polars* ]]; then
+            echo "ref=polars" >> "$GITHUB_OUTPUT"
+          else
+            echo "ref=main" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Install pyledger
-        run: pip install git+https://x-access-token:${{ secrets.PYLEDGER_CI_ACCESS_TOKEN }}@github.com/macxred/pyledger.git@main
+        run: pip install git+https://x-access-token:${{ secrets.PYLEDGER_CI_ACCESS_TOKEN }}@github.com/macxred/pyledger.git@${{ steps.pyledger-branch.outputs.ref }}
 
       - name: Install dependencies
         run: pip install coverage pytest setuptools .

--- a/cashctrl_ledger/accounts.py
+++ b/cashctrl_ledger/accounts.py
@@ -2,33 +2,41 @@
 
 from typing import Dict, List
 import pandas as pd
-from consistent_df import enforce_schema, unnest
+import polars as pl
+from pyledger.schema import enforce_schema, ensure_polars, to_polars
 from .cashctrl_accounting_entity import CashCtrlAccountingEntity
 
 
 class Account(CashCtrlAccountingEntity):
     """Provides account accessors and mutators for CashCtrl."""
 
-    def list(self) -> pd.DataFrame:
-        accounts = self._client.list_accounts()
-        result = pd.DataFrame({
+    def list(self, pandas: bool = True) -> pd.DataFrame | pl.DataFrame:
+        accounts = to_polars(self._client.list_accounts())
+        result = pl.DataFrame({
             "account": accounts["number"],
             "currency": accounts["currencyCode"],
             "description": accounts["name"],
             "tax_code": accounts["taxName"],
             "group": accounts["path"],
         })
-        result = self.standardize(result)
+        result = self.standardize(result, pandas=False)
         # Fill persistent and multiplier columns with values based on account number
         # (same logic as LedgerEngine.sanitize_accounts) since CashCtrl doesn't store them
-        result["persistent"] = (result["account"] < 3000).astype("boolean")
-        result["multiplier"] = result["account"].apply(
-            lambda acc: 1 if acc < 2000 else -1
-        ).astype("Int64")
+        result = result.with_columns(
+            persistent=(pl.col("account") < 3000),
+            multiplier=pl.when(pl.col("account") < 2000)
+            .then(pl.lit(1, dtype=pl.Int64)).otherwise(pl.lit(-1, dtype=pl.Int64)),
+        )
+
+        if pandas:
+            from pyledger.schema import to_pandas
+            return to_pandas(result, self._schema)
         return result
 
-    def add(self, data: pd.DataFrame):
-        incoming = self.standardize(pd.DataFrame(data))
+    def add(self, data: pd.DataFrame | pl.DataFrame) -> None:
+        incoming = self.standardize(
+            ensure_polars(data, "Account.add"), pandas=False,
+        )
 
         # Update account categories
         self._client.update_categories(
@@ -36,25 +44,28 @@ class Account(CashCtrlAccountingEntity):
             delete=False, ignore_account_root_nodes=True,
         )
 
-        for _, row in incoming.iterrows():
+        for row in incoming.iter_rows(named=True):
             payload = {
                 "number": row["account"],
                 "currencyId": self._client.currency_to_id(row["currency"]),
                 "name": row["description"],
-                "taxId": None if pd.isna(row["tax_code"])
+                "taxId": None if row["tax_code"] is None
                 else self._client.tax_code_to_id(row["tax_code"]),
-                "categoryId": self._client.account_category_to_id(row["group"]),
+                "categoryId": self._client.account_category_to_id(
+                    "/" + row["group"].strip("/")
+                ),
             }
             self._client.post("account/create.json", data=payload)
         self._client.list_accounts.cache_clear()
 
-    def modify(self, data: pd.DataFrame):
-        data = pd.DataFrame(data)
-        cols = set(self._schema["column"]).intersection(data.columns)
-        cols = cols.union(self._schema.query("id")["column"])
-        reduced_schema = self._schema.query("column in @cols")
+    def modify(self, data: pd.DataFrame | pl.DataFrame) -> None:
+        data = ensure_polars(data, "Account.modify")
+        schema_cols = self._schema["column"].to_list()
+        id_cols = self._schema.filter(pl.col("id"))["column"].to_list()
+        cols = list(set(schema_cols).intersection(data.columns).union(set(id_cols)))
+        reduced_schema = self._schema.filter(pl.col("column").is_in(cols))
         incoming = enforce_schema(data, reduced_schema, keep_extra_columns=True)
-        current = self.list()
+        current = self.list(pandas=False)
 
         # Update account categories
         if "group" in cols:
@@ -63,13 +74,15 @@ class Account(CashCtrlAccountingEntity):
                 delete=False, ignore_account_root_nodes=True,
             )
 
-        for _, row in incoming.iterrows():
-            existing = current.query("account == @row['account']")
+        for row in incoming.iter_rows(named=True):
+            existing = current.filter(pl.col("account") == row["account"])
 
             # Specify required fields for CashCtrl
             payload = {"id": self._client.account_to_id(row["account"])}
-            group = row["group"] if "group" in incoming.columns else existing["group"].item()
-            payload["categoryId"] = self._client.account_category_to_id(group)
+            group = row["group"] if "group" in incoming.columns else existing["group"][0]
+            payload["categoryId"] = self._client.account_category_to_id(
+                "/" + group.strip("/")
+            )
 
             # Specify optional fields for CashCtrl
             if "account" in incoming.columns:
@@ -79,23 +92,26 @@ class Account(CashCtrlAccountingEntity):
             if "description" in incoming.columns:
                 payload["name"] = row["description"]
             if "tax_code" in incoming.columns:
-                payload["taxId"] = None if pd.isna(row["tax_code"]) else \
+                payload["taxId"] = None if row["tax_code"] is None else \
                     self._client.tax_code_to_id(row["tax_code"])
             self._client.post("account/update.json", data=payload)
         self._client.list_accounts.cache_clear()
 
-    def delete(self, id: pd.DataFrame, allow_missing: bool = False) -> None:
-        incoming = enforce_schema(pd.DataFrame(id), self._schema.query("id"))
+    def delete(self, id: pd.DataFrame | pl.DataFrame, allow_missing: bool = False) -> None:
+        incoming = enforce_schema(
+            ensure_polars(id, "Account.delete"),
+            self._schema.filter(pl.col("id")),
+        )
         ids = []
-        for account in incoming["account"]:
-            id = self._client.account_to_id(account, allow_missing)
-            if id is not None:
-                ids.append(str(id))
+        for account in incoming["account"].to_list():
+            remote_id = self._client.account_to_id(account, allow_missing)
+            if remote_id is not None:
+                ids.append(str(remote_id))
         if len(ids):
             self._client.post("account/delete.json", {"ids": ", ".join(ids)})
             self._client.list_accounts.cache_clear()
 
-    def mirror(self, target: pd.DataFrame, delete: bool = False):
+    def mirror(self, target: pd.DataFrame | pl.DataFrame, delete: bool = False):
         """Synchronize remote CashCtrl accounts with the target DataFrame.
 
         Updates categories first, then invokes the parent class method.
@@ -107,15 +123,20 @@ class Account(CashCtrlAccountingEntity):
         - Mirroring accounts with non-existing root categories raises an error.
 
         Args:
-            target (pd.DataFrame): DataFrame with an account chart in the pyledger format.
+            target: DataFrame with an account chart in the pyledger format.
             delete (bool, optional): If True, deletes remote accounts not present in the target.
         """
-        current = self.list()
-        target = self.standardize(target)
+        current = self.list(pandas=False)
+        target = self.standardize(
+            ensure_polars(target, "Account.mirror"), pandas=False,
+        )
 
         # Delete superfluous accounts on remote
         if delete:
-            self.delete(current[~current["account"].isin(target["account"])])
+            to_delete = current.filter(
+                ~pl.col("account").is_in(target["account"].to_list())
+            )
+            self.delete(to_delete)
 
         # Update account categories
         self._client.update_categories(
@@ -131,11 +152,19 @@ class Account(CashCtrlAccountingEntity):
         parts = path.strip("/").split("/")
         return ["/" + "/".join(parts[:i]) for i in range(1, len(parts) + 1)]
 
-    def _account_groups(self, df: pd.DataFrame) -> Dict[str, str]:
+    def _account_groups(self, df: pl.DataFrame) -> Dict[str, str]:
         """Find lowest account number associated with each node in the group tree."""
-        if df is None or df.empty:
+        if df is None or len(df) == 0:
             return {}
-        df = df.copy()
-        df["nodes"] = [pd.DataFrame({"items": self._get_nodes_list(path)}) for path in df["group"]]
-        df = unnest(df, key="nodes")
-        return df.groupby("items")["account"].agg("min").to_dict()
+
+        rows = []
+        for row in df.iter_rows(named=True):
+            for node in self._get_nodes_list(row["group"]):
+                rows.append({"items": node, "account": row["account"]})
+
+        expanded = pl.DataFrame(rows)
+        return dict(
+            expanded.group_by("items").agg(
+                account=pl.col("account").min()
+            ).iter_rows()
+        )

--- a/cashctrl_ledger/accounts.py
+++ b/cashctrl_ledger/accounts.py
@@ -3,7 +3,7 @@
 from typing import Dict, List
 import pandas as pd
 import polars as pl
-from pyledger.schema import enforce_schema, ensure_polars, to_polars
+from pyledger.schema import enforce_schema, ensure_polars, to_pandas, to_polars
 from .cashctrl_accounting_entity import CashCtrlAccountingEntity
 
 
@@ -29,11 +29,10 @@ class Account(CashCtrlAccountingEntity):
         )
 
         if pandas:
-            from pyledger.schema import to_pandas
             return to_pandas(result, self._schema)
         return result
 
-    def add(self, data: pd.DataFrame | pl.DataFrame) -> None:
+    def add(self, data: pd.DataFrame | pl.DataFrame):
         incoming = self.standardize(
             ensure_polars(data, "Account.add"), pandas=False,
         )
@@ -51,14 +50,12 @@ class Account(CashCtrlAccountingEntity):
                 "name": row["description"],
                 "taxId": None if row["tax_code"] is None
                 else self._client.tax_code_to_id(row["tax_code"]),
-                "categoryId": self._client.account_category_to_id(
-                    "/" + row["group"].strip("/")
-                ),
+                "categoryId": self._client.account_category_to_id(row["group"]),
             }
             self._client.post("account/create.json", data=payload)
         self._client.list_accounts.cache_clear()
 
-    def modify(self, data: pd.DataFrame | pl.DataFrame) -> None:
+    def modify(self, data: pd.DataFrame | pl.DataFrame):
         data = ensure_polars(data, "Account.modify")
         schema_cols = self._schema["column"].to_list()
         id_cols = self._schema.filter(pl.col("id"))["column"].to_list()
@@ -80,9 +77,7 @@ class Account(CashCtrlAccountingEntity):
             # Specify required fields for CashCtrl
             payload = {"id": self._client.account_to_id(row["account"])}
             group = row["group"] if "group" in incoming.columns else existing["group"][0]
-            payload["categoryId"] = self._client.account_category_to_id(
-                "/" + group.strip("/")
-            )
+            payload["categoryId"] = self._client.account_category_to_id(group)
 
             # Specify optional fields for CashCtrl
             if "account" in incoming.columns:
@@ -104,9 +99,9 @@ class Account(CashCtrlAccountingEntity):
         )
         ids = []
         for account in incoming["account"].to_list():
-            remote_id = self._client.account_to_id(account, allow_missing)
-            if remote_id is not None:
-                ids.append(str(remote_id))
+            id = self._client.account_to_id(account, allow_missing)
+            if id is not None:
+                ids.append(str(id))
         if len(ids):
             self._client.post("account/delete.json", {"ids": ", ".join(ids)})
             self._client.list_accounts.cache_clear()
@@ -123,7 +118,8 @@ class Account(CashCtrlAccountingEntity):
         - Mirroring accounts with non-existing root categories raises an error.
 
         Args:
-            target: DataFrame with an account chart in the pyledger format.
+            target (pd.DataFrame | pl.DataFrame): DataFrame with an account chart
+                in the pyledger format.
             delete (bool, optional): If True, deletes remote accounts not present in the target.
         """
         current = self.list(pandas=False)

--- a/cashctrl_ledger/constants.py
+++ b/cashctrl_ledger/constants.py
@@ -1,18 +1,12 @@
 """This module contains constants used throughout the application."""
 
-import pandas as pd
-from io import StringIO
+from pyledger.schema import read_schema as _read_schema_pl
 
 
-JOURNAL_ITEM_COLUMNS = {
-    "accountId": "int",
-    "description": "string[python]",
-    "debit": "float64",
-    "credit": "float64",
-    "taxName": "string[python]",
-    "associateName": "string[python]",
-    "allocations": "object",
-}
+JOURNAL_ITEM_COLUMNS = [
+    "accountId", "description", "debit", "credit",
+    "taxName", "associateName",
+]
 
 
 CONFIGURATION_KEYS = [
@@ -37,20 +31,20 @@ FISCAL_PERIOD_SCHEMA_CSV = """
         start,     datetime64[ns],        True,     False
           end,     datetime64[ns],        True,     False
          name,     string[python],        True,     False
-    isCurrent,               bool,        True,     False
+    isCurrent,            boolean,        True,     False
 """
-FISCAL_PERIOD_SCHEMA = pd.read_csv(StringIO(FISCAL_PERIOD_SCHEMA_CSV), skipinitialspace=True)
+FISCAL_PERIOD_SCHEMA = _read_schema_pl(FISCAL_PERIOD_SCHEMA_CSV)
 
 
 REPORT_ELEMENT_SCHEMA_CSV = """
        column,              dtype,   mandatory,     id
-   endAmount2,            float64,       False,     False
- dcEndAmount2,            float64,       False,     False
+   endAmount2,            Float64,       False,     False
+ dcEndAmount2,            Float64,       False,     False
     accountId,              Int64,       False,     True
  currencyCode,     string[python],       False,     False
          path,     string[python],       False,     False
 """
-REPORT_ELEMENT = pd.read_csv(StringIO(REPORT_ELEMENT_SCHEMA_CSV), skipinitialspace=True)
+REPORT_ELEMENT = _read_schema_pl(REPORT_ELEMENT_SCHEMA_CSV)
 
 
 ACCOUNT_ROOT_CATEGORIES = ["Assets", "Balance", "Expense", "Liabilities & Equity", "Revenue"]

--- a/cashctrl_ledger/extended_ledger.py
+++ b/cashctrl_ledger/extended_ledger.py
@@ -112,11 +112,12 @@ class ExtendedCashCtrlLedger(CashCtrlLedger):
           using the designated `transitory_account`.
 
         Args:
-            journal: The journal DataFrame with transactions to be processed.
+            journal (pd.DataFrame | pl.DataFrame): The journal DataFrame with
+                transactions to be processed.
             pandas: If True, return pandas DataFrame; otherwise polars.
 
         Returns:
-            The modified journal DataFrame.
+            pd.DataFrame | pl.DataFrame: The modified journal DataFrame.
         """
         journal = self.journal.standardize(
             ensure_polars(journal, "ExtendedCashCtrlLedger.sanitize_journal"),
@@ -132,13 +133,11 @@ class ExtendedCashCtrlLedger(CashCtrlLedger):
                 currency=null_rows['currency'].to_list(),
                 date=null_rows['date'].to_list(),
             )
-            report_col = journal['report_amount'].to_list()
-            null_indices = mask.arg_true().to_list()
-            for i, idx in enumerate(null_indices):
-                report_col[idx] = filled[i]
-            journal = journal.with_columns(
-                report_amount=pl.Series(report_col, dtype=pl.Float64),
+            col = journal['report_amount'].fill_nan(None)
+            col = col.scatter(
+                mask.arg_true(), pl.Series(filled, dtype=pl.Float64),
             )
+            journal = journal.with_columns(report_amount=col)
 
         # Number of currencies other than reporting currency
         reporting_currency = self.reporting_currency
@@ -148,7 +147,7 @@ class ExtendedCashCtrlLedger(CashCtrlLedger):
         )
         multi_ids = n_currency.filter(pl.col("n") > 1)["id"].to_list()
 
-        # Split entries with multiple currencies into separate entries
+        # Split entries with multiple currencies into separate entries for each currency
         if len(multi_ids) > 0:
             multi_currency = self.journal.standardize(
                 journal.filter(pl.col("id").is_in(multi_ids)), pandas=False,
@@ -161,11 +160,10 @@ class ExtendedCashCtrlLedger(CashCtrlLedger):
         else:
             df = journal
 
-        # Ensure foreign currencies can be mapped, correct with FX adjustments
+        # Ensure foreign currencies can be mapped, correct with FX adjustments otherwise
         transitory_account = self.transitory_account
         result = []
-        for txn_id in df["id"].unique(maintain_order=True).to_list():
-            txn = df.filter(pl.col("id") == txn_id)
+        for txn in df.partition_by("id", maintain_order=True):
             new_txn = self._add_fx_adjustment(
                 txn,
                 transitory_account=transitory_account,
@@ -188,27 +186,25 @@ class ExtendedCashCtrlLedger(CashCtrlLedger):
         pandas: bool = True,
     ) -> pd.DataFrame | pl.DataFrame:
         """
-        Splits multi-currency transactions into individual transactions
-        for each currency.
+        Splits multi-currency transactions into individual transactions for each currency.
 
-        CashCtrl restricts collective transactions to a single currency beyond
-        the reporting currency. This method splits multi-currency transactions
-        into several transactions compatible with CashCtrl, each involving a
-        single currency and possibly the reporting currency. If there is a
-        residual balance in any currency, it is recorded in the
-        `transitory_account`. The total of all entries in the transitory
+        CashCtrl restricts collective transactions to a single currency beyond the reporting
+        currency. This method splits multi-currency transactions into several transactions
+        compatible with CashCtrl, each involving a single currency and possibly
+        the reporting currency. If there is a residual balance in any currency, it is
+        recorded in the `transitory_account`. The total of all entries in the transitory
         account across these transactions will balance to zero.
 
         Args:
-            journal: The journal DataFrame containing transactions to be split.
-            transitory_account: The account number for recording balancing
-                entries. If not provided, the instance's transitory_account
-                will be used.
+            journal (pd.DataFrame | pl.DataFrame): The journal DataFrame containing
+                transactions to be split.
+            transitory_account (int, optional): The account number for recording balancing
+                entries. If not provided, the instance's `transitory_account` will be used.
             pandas: If True, return pandas DataFrame; otherwise polars.
 
         Returns:
-            Modified journal entries with split transactions and any necessary
-                balancing entries.
+            pd.DataFrame | pl.DataFrame: Modified journal entries with split transactions
+                and any necessary balancing entries.
         """
         journal = ensure_polars(
             journal, "ExtendedCashCtrlLedger.split_multi_currency_transactions",
@@ -265,24 +261,21 @@ class ExtendedCashCtrlLedger(CashCtrlLedger):
         reporting_currency: str,
     ) -> pl.DataFrame:
         """
-        Adjusts journal entries to conform with CashCtrl's eight-digit FX
-        rate precision.
+        Adjusts journal entries to conform with CashCtrl's eight-digit FX rate precision.
 
-        This method ensures that the reporting currency amounts in a journal
-        entry match CashCtrl's precision limit for foreign exchange rates of
-        eight digits after the decimal point. If an adjustment is needed due
-        to rounding differences, it adds a balancing journal entry using the
-        `transitory_account`, so the financial result remains consistent.
+        This method ensures that the reporting currency amounts in a journal entry match
+        CashCtrl's precision limit for foreign exchange rates of eight digits after
+        the decimal point. If an adjustment is needed due to rounding differences,
+        it adds a balancing journal entry using the `transitory_account`, so the
+        financial result remains consistent.
 
         Args:
-            entry: The journal entry or entries to be adjusted.
-            transitory_account: The account number for recording balancing
-                transactions.
-            reporting_currency: The reporting currency against which
-                adjustments are made.
+            entry (pl.DataFrame): The journal entry or entries to be adjusted.
+            transitory_account (int): The account number for recording balancing transactions.
+            reporting_currency (str): The reporting currency against which adjustments are made.
 
         Returns:
-            The adjusted journal entries and any necessary balancing entries.
+            pl.DataFrame: The adjusted journal entries and any necessary balancing entries.
         """
         if len(entry) == 1:
             # Individual transaction: one row in the journal data frame
@@ -359,15 +352,13 @@ class ExtendedCashCtrlLedger(CashCtrlLedger):
                 # Convert reporting currency rows to foreign currency
                 is_reporting = entry["currency"] == reporting_currency
                 if is_reporting.any():
-                    report_amounts = entry["report_amount"]
-                    amounts = entry["amount"].to_list()
-                    currencies = entry["currency"].to_list()
-                    for i in is_reporting.arg_true().to_list():
-                        amounts[i] = report_amounts[i] / fx_rate
-                        currencies[i] = currency
                     entry = entry.with_columns(
-                        amount=pl.Series(amounts, dtype=pl.Float64),
-                        currency=pl.Series(currencies, dtype=pl.String),
+                        amount=pl.when(is_reporting)
+                        .then(pl.col("report_amount") / fx_rate)
+                        .otherwise(pl.col("amount")),
+                        currency=pl.when(is_reporting)
+                        .then(pl.lit(currency))
+                        .otherwise(pl.col("currency")),
                     )
                 entry = entry.with_columns(
                     amount=pl.Series(self.round_to_precision(
@@ -449,14 +440,13 @@ class ExtendedCashCtrlLedger(CashCtrlLedger):
                     [currency], [entry["date"][0]],
                 )[0]
                 if abs(rounding_error) > currency_precision / 2:
-                    # Rounding after converting foreign currency amounts to
-                    # reporting currency amounts by multipying with FX rate
-                    # leads to rounding differences that sum up to a net
-                    # rounding difference equal or larger than currency
-                    # precision (0.01 for CHF, EUR, USD, etc.).
+                    # Rounding after converting foreign currency amounts to reporting
+                    # currency amounts by multipying with FX rate leads to rounding
+                    # differences that sum up to a net rounding difference equal or
+                    # larger than currency precision (0.01 for CHF, EUR, USD, etc.).
                     # -> We compensate this rounding difference by creating
-                    #    transactions that have rounding differences with the
-                    #    same amount but opposite sign.
+                    #    transactions that have rounding differences with the same
+                    #    amount but opposite sign.
                     # 1. Create a transaction with one cent rounding difference
                     first_row = entry.row(0, named=True)
                     txn_id = str(first_row["id"]) + ":rounding"

--- a/cashctrl_ledger/extended_ledger.py
+++ b/cashctrl_ledger/extended_ledger.py
@@ -2,8 +2,10 @@
 directly represented in CahCtrl.
 """
 
-import numpy as np
+import math
 import pandas as pd
+import polars as pl
+from pyledger.schema import ensure_polars, to_pandas
 from .ledger import CashCtrlLedger
 
 
@@ -95,7 +97,10 @@ class ExtendedCashCtrlLedger(CashCtrlLedger):
     # ----------------------------------------------------------------------
     # Journal
 
-    def sanitize_journal(self, journal: pd.DataFrame) -> pd.DataFrame:
+    def sanitize_journal(
+        self, journal: pd.DataFrame | pl.DataFrame,
+        pandas: bool = True,
+    ) -> pd.DataFrame | pl.DataFrame:
         """Modify journal to ensure coherence and compatibility with CashCtrl.
 
         Extends the base `sanitize_journal` to address CashCtrl-specific constraints:
@@ -107,285 +112,418 @@ class ExtendedCashCtrlLedger(CashCtrlLedger):
           using the designated `transitory_account`.
 
         Args:
-            journal (pd.DataFrame): The journal DataFrame with transactions to be processed.
+            journal: The journal DataFrame with transactions to be processed.
+            pandas: If True, return pandas DataFrame; otherwise polars.
 
         Returns:
-            pd.DataFrame: The modified journal DataFrame.
+            The modified journal DataFrame.
         """
-        journal = self.journal.standardize(journal)
+        journal = self.journal.standardize(
+            ensure_polars(journal, "ExtendedCashCtrlLedger.sanitize_journal"),
+            pandas=False,
+        )
 
         # Insert missing base currency amounts
-        mask = journal['report_amount'].isna()
-        journal.loc[mask, 'report_amount'] = self.report_amount(
-            amount=journal.loc[mask, 'amount'],
-            currency=journal.loc[mask, 'currency'],
-            date=journal.loc[mask, 'date']
-        )
+        mask = journal['report_amount'].fill_nan(None).is_null()
+        if mask.any():
+            null_rows = journal.filter(mask)
+            filled = self.report_amount(
+                amount=null_rows['amount'].to_list(),
+                currency=null_rows['currency'].to_list(),
+                date=null_rows['date'].to_list(),
+            )
+            report_col = journal['report_amount'].to_list()
+            null_indices = mask.arg_true().to_list()
+            for i, idx in enumerate(null_indices):
+                report_col[idx] = filled[i]
+            journal = journal.with_columns(
+                report_amount=pl.Series(report_col, dtype=pl.Float64),
+            )
 
         # Number of currencies other than reporting currency
         reporting_currency = self.reporting_currency
-        n_currency = journal[["id", "currency"]][journal["currency"] != reporting_currency]
-        n_currency = n_currency.groupby("id")["currency"].nunique()
+        foreign = journal.filter(pl.col("currency") != reporting_currency)
+        n_currency = foreign.group_by("id").agg(
+            n=pl.col("currency").n_unique()
+        )
+        multi_ids = n_currency.filter(pl.col("n") > 1)["id"].to_list()
 
-        # Split entries with multiple currencies into separate entries for each currency
-        ids = n_currency.index[n_currency > 1]
-        if len(ids) > 0:
-            multi_currency = self.journal.standardize(journal[journal["id"].isin(ids)])
-            multi_currency = self.split_multi_currency_transactions(multi_currency)
-            others = journal[~journal["id"].isin(ids)]
-            df = pd.concat([others, multi_currency], ignore_index=True)
+        # Split entries with multiple currencies into separate entries
+        if len(multi_ids) > 0:
+            multi_currency = self.journal.standardize(
+                journal.filter(pl.col("id").is_in(multi_ids)), pandas=False,
+            )
+            multi_currency = self.split_multi_currency_transactions(
+                multi_currency, pandas=False,
+            )
+            others = journal.filter(~pl.col("id").is_in(multi_ids))
+            df = pl.concat([others, multi_currency], how="diagonal")
         else:
             df = journal
 
-        # Ensure foreign currencies can be mapped, correct with FX adjustments otherwise
+        # Ensure foreign currencies can be mapped, correct with FX adjustments
         transitory_account = self.transitory_account
         result = []
-        for _, txn in df.groupby("id"):
+        for txn_id in df["id"].unique(maintain_order=True).to_list():
+            txn = df.filter(pl.col("id") == txn_id)
             new_txn = self._add_fx_adjustment(
-                txn, transitory_account=transitory_account, reporting_currency=reporting_currency
+                txn,
+                transitory_account=transitory_account,
+                reporting_currency=reporting_currency,
             )
-            result.append(self.journal.standardize(new_txn))
+            result.append(self.journal.standardize(new_txn, pandas=False))
+
         if len(result) > 0:
-            result = pd.concat(result)
+            result = pl.concat(result, how="diagonal")
         else:
             result = df
 
+        if pandas:
+            return to_pandas(result, self.journal._schema)
         return result
 
-    def split_multi_currency_transactions(self, journal: pd.DataFrame,
-                                          transitory_account: int | None = None) -> pd.DataFrame:
+    def split_multi_currency_transactions(
+        self, journal: pd.DataFrame | pl.DataFrame,
+        transitory_account: int | None = None,
+        pandas: bool = True,
+    ) -> pd.DataFrame | pl.DataFrame:
         """
-        Splits multi-currency transactions into individual transactions for each currency.
+        Splits multi-currency transactions into individual transactions
+        for each currency.
 
-        CashCtrl restricts collective transactions to a single currency beyond the reporting
-        currency. This method splits multi-currency transactions into several transactions
-        compatible with CashCtrl, each involving a single currency and possibly
-        the reporting currency. If there is a residual balance in any currency, it is
-        recorded in the `transitory_account`. The total of all entries in the transitory
+        CashCtrl restricts collective transactions to a single currency beyond
+        the reporting currency. This method splits multi-currency transactions
+        into several transactions compatible with CashCtrl, each involving a
+        single currency and possibly the reporting currency. If there is a
+        residual balance in any currency, it is recorded in the
+        `transitory_account`. The total of all entries in the transitory
         account across these transactions will balance to zero.
 
         Args:
-            journal (pd.DataFrame): The journal DataFrame containing transactions to be split.
-            transitory_account (int, optional): The account number for recording balancing
-                entries. If not provided, the instance's `transitory_account` will be used.
+            journal: The journal DataFrame containing transactions to be split.
+            transitory_account: The account number for recording balancing
+                entries. If not provided, the instance's transitory_account
+                will be used.
+            pandas: If True, return pandas DataFrame; otherwise polars.
 
         Returns:
-            pd.DataFrame: Modified journal entries with split transactions and any necessary
+            Modified journal entries with split transactions and any necessary
                 balancing entries.
         """
+        journal = ensure_polars(
+            journal, "ExtendedCashCtrlLedger.split_multi_currency_transactions",
+        )
         reporting_currency = self.reporting_currency
-        is_reporting_currency = journal["currency"] == reporting_currency
-        journal.loc[is_reporting_currency, "report_amount"] = journal.loc[
-            is_reporting_currency, "amount"
-        ]
+        is_reporting = journal["currency"] == reporting_currency
+        journal = journal.with_columns(
+            report_amount=pl.when(is_reporting)
+            .then(pl.col("amount"))
+            .otherwise(pl.col("report_amount")),
+        )
 
-        if any(journal["report_amount"].isna()):
-            raise ValueError("Reporting currency amount missing for some items.")
+        if journal["report_amount"].is_null().any():
+            raise ValueError(
+                "Reporting currency amount missing for some items."
+            )
         if transitory_account is None:
             transitory_account = self.transitory_account
 
         result = []
-        for (id, currency), group in journal.groupby(["id", "currency"]):
-            sub_id = f"{id}:{currency}"
-            result.append(group.assign(id=sub_id))
-            balance = self.round_to_precision(group["report_amount"].sum(), reporting_currency)
+        for (txn_id, currency), group in journal.group_by(
+            ["id", "currency"], maintain_order=True,
+        ):
+            sub_id = f"{txn_id}:{currency}"
+            result.append(
+                group.with_columns(id=pl.lit(sub_id))
+            )
+            balance = self.round_to_precision(
+                group["report_amount"].sum(), reporting_currency,
+            )
             if balance != 0:
-                clearing_txn = pd.DataFrame(
-                    {
-                        "id": [sub_id],
-                        "description": [
-                            "Split multi-currency transaction "
-                            "into multiple transactions compatible with CashCtrl."
-                        ],
-                        "amount": [-1 * balance],
-                        "report_amount": [-1 * balance],
-                        "currency": [reporting_currency],
-                        "account": [transitory_account],
-                    }
-                )
+                clearing_txn = pl.DataFrame({
+                    "id": [sub_id],
+                    "description": [
+                        "Split multi-currency transaction "
+                        "into multiple transactions compatible with CashCtrl."
+                    ],
+                    "amount": [-1 * balance],
+                    "report_amount": [-1 * balance],
+                    "currency": [reporting_currency],
+                    "account": [transitory_account],
+                })
                 result.append(clearing_txn)
 
-        result = pd.concat(result, ignore_index=True)
-        return self.journal.standardize(result)
+        result = pl.concat(result, how="diagonal")
+        result = self.journal.standardize(result, pandas=False)
+
+        if pandas:
+            return to_pandas(result, self.journal._schema)
+        return result
 
     def _add_fx_adjustment(
-        self, entry: pd.DataFrame, transitory_account: int, reporting_currency: str
-    ) -> pd.DataFrame:
+        self, entry: pl.DataFrame, transitory_account: int,
+        reporting_currency: str,
+    ) -> pl.DataFrame:
         """
-        Adjusts journal entries to conform with CashCtrl's eight-digit FX rate precision.
+        Adjusts journal entries to conform with CashCtrl's eight-digit FX
+        rate precision.
 
-        This method ensures that the reporting currency amounts in a journal entry match
-        CashCtrl's precision limit for foreign exchange rates of eight digits after
-        the decimal point. If an adjustment is needed due to rounding differences,
-        it adds a balancing journal entry using the `transitory_account`, so the
-        financial result remains consistent.
+        This method ensures that the reporting currency amounts in a journal
+        entry match CashCtrl's precision limit for foreign exchange rates of
+        eight digits after the decimal point. If an adjustment is needed due
+        to rounding differences, it adds a balancing journal entry using the
+        `transitory_account`, so the financial result remains consistent.
 
         Args:
-            entry (pd.DataFrame): The journal entry or entries to be adjusted.
-            transitory_account (int): The account number for recording balancing transactions.
-            reporting_currency (str): The reporting currency against which adjustments are made.
+            entry: The journal entry or entries to be adjusted.
+            transitory_account: The account number for recording balancing
+                transactions.
+            reporting_currency: The reporting currency against which
+                adjustments are made.
 
         Returns:
-            pd.DataFrame: The adjusted journal entries and any necessary balancing entries.
+            The adjusted journal entries and any necessary balancing entries.
         """
         if len(entry) == 1:
             # Individual transaction: one row in the journal data frame
-            if (
-                entry["amount"].item() == 0
-                or entry["currency"].item() == reporting_currency
-            ):
+            row = entry.row(0, named=True)
+            if row["amount"] == 0 or row["currency"] == reporting_currency:
                 return entry
             else:
-                amount = self.round_to_precision(entry["amount"].item(), entry["currency"].item())
+                amount = self.round_to_precision(
+                    row["amount"], row["currency"],
+                )
                 reporting_amount = self.round_to_precision(
-                    entry["report_amount"].item(), reporting_currency
+                    row["report_amount"], reporting_currency,
                 )
                 fx_rate = round(reporting_amount / amount, 8)
                 balance = reporting_amount - self.round_to_precision(
-                    amount * fx_rate, reporting_currency
+                    amount * fx_rate, reporting_currency,
                 )
                 if balance == 0.0:
                     return entry
                 else:
-                    balancing_txn = entry.copy()
-                    balancing_txn["id"] = balancing_txn["id"] + ":fx"
-                    balancing_txn["currency"] = entry["currency"].item()
-                    balancing_txn["amount"] = 0
-                    balancing_txn["report_amount"] = balance
-                    entry["report_amount"] = (
-                        entry["report_amount"] - balance
+                    balancing_txn = entry.clone().with_columns(
+                        id=pl.format("{}:fx", pl.col("id")),
+                        currency=pl.lit(row["currency"]),
+                        amount=pl.lit(0.0),
+                        report_amount=pl.lit(balance),
                     )
-                    result = pd.concat(
+                    entry = entry.with_columns(
+                        report_amount=pl.col("report_amount") - balance,
+                    )
+                    result = pl.concat(
                         [
-                            self.journal.standardize(entry),
-                            self.journal.standardize(balancing_txn),
-                        ]
+                            self.journal.standardize(entry, pandas=False),
+                            self.journal.standardize(
+                                balancing_txn, pandas=False,
+                            ),
+                        ],
+                        how="diagonal",
                     )
-                    result["amount"] = self.round_to_precision(
-                        result["amount"], result["currency"]
+                    result = result.with_columns(
+                        amount=pl.Series(self.round_to_precision(
+                            result["amount"], result["currency"],
+                        )),
+                        report_amount=pl.Series(self.round_to_precision(
+                            result["report_amount"],
+                            pl.Series([reporting_currency] * len(result)),
+                        )),
                     )
-                    result["report_amount"] = self.round_to_precision(
-                        result["report_amount"], reporting_currency
-                    )
-                    return self.journal.standardize(result)
+                    return self.journal.standardize(result, pandas=False)
 
         elif len(entry) > 1:
             # Collective transaction: multiple rows in the journal data frame
-            currency, fx_rate = self._collective_transaction_currency_and_rate(entry)
+            currency, fx_rate = \
+                self._collective_transaction_currency_and_rate(entry)
             fx_rate = round(fx_rate, 8)
             if currency == reporting_currency:
                 return entry
             else:
-                mask = (entry["currency"] == reporting_currency) & entry["report_amount"].isna()
-                entry.loc[mask, "report_amount"] = entry.loc[mask, "amount"]
-                entry["report_amount"] = self.round_to_precision(
-                    entry["report_amount"], reporting_currency,
+                is_reporting = entry["currency"] == reporting_currency
+                has_null_report = entry["report_amount"].is_null()
+                entry = entry.with_columns(
+                    report_amount=pl.when(is_reporting & has_null_report)
+                    .then(pl.col("amount"))
+                    .otherwise(pl.col("report_amount")),
                 )
-                if entry["report_amount"].isna().any():
+                entry = entry.with_columns(
+                    report_amount=pl.Series(self.round_to_precision(
+                        entry["report_amount"],
+                        pl.Series([reporting_currency] * len(entry)),
+                    )),
+                )
+                if entry["report_amount"].is_null().any():
                     raise ValueError("Reporting currency missing.")
-                mask = (entry["currency"] == reporting_currency)
-                if mask.any():
-                    entry.loc[mask, "amount"] = entry.loc[mask, "report_amount"] / fx_rate
-                    entry.loc[mask, "currency"] = currency
-                entry["amount"] = self.round_to_precision(entry["amount"], entry["currency"])
-                entry = self._add_balancing_leg(entry, fx_rate=fx_rate,
-                                                account=transitory_account, currency=currency)
-                balance = entry["report_amount"] - np.array(
-                    self.round_to_precision(entry["amount"] * fx_rate, reporting_currency)
+
+                # Convert reporting currency rows to foreign currency
+                is_reporting = entry["currency"] == reporting_currency
+                if is_reporting.any():
+                    report_amounts = entry["report_amount"]
+                    amounts = entry["amount"].to_list()
+                    currencies = entry["currency"].to_list()
+                    for i in is_reporting.arg_true().to_list():
+                        amounts[i] = report_amounts[i] / fx_rate
+                        currencies[i] = currency
+                    entry = entry.with_columns(
+                        amount=pl.Series(amounts, dtype=pl.Float64),
+                        currency=pl.Series(currencies, dtype=pl.String),
+                    )
+                entry = entry.with_columns(
+                    amount=pl.Series(self.round_to_precision(
+                        entry["amount"], entry["currency"],
+                    )),
                 )
-                balance = np.array(self.round_to_precision(balance, reporting_currency))
-                if all(balance == 0.0):
+                entry = self._add_balancing_leg(
+                    entry, fx_rate=fx_rate,
+                    account=transitory_account, currency=currency,
+                )
+
+                amounts = entry["amount"]
+                report_amounts = entry["report_amount"]
+                balance = report_amounts - pl.Series(self.round_to_precision(
+                    amounts * fx_rate,
+                    pl.Series([reporting_currency] * len(entry)),
+                ))
+                balance = pl.Series(self.round_to_precision(
+                    balance, pl.Series([reporting_currency] * len(balance)),
+                ))
+
+                if (balance == 0.0).all():
                     result = entry
                 else:
-                    entry["report_amount"] = entry["report_amount"] - balance
-                    fx_adjust = entry.copy()
-                    fx_adjust["currency"] = reporting_currency
-                    fx_adjust["report_amount"] = balance
-                    fx_adjust["amount"] = fx_adjust["report_amount"]
-                    fx_adjust["id"] = fx_adjust["id"] + ":fx"
-                    fx_adjust["description"] = (
-                        "Currency adjustments: " + fx_adjust["description"]
+                    entry = entry.with_columns(
+                        report_amount=pl.col("report_amount") - balance,
                     )
-                    fx_adjust = fx_adjust[fx_adjust["report_amount"] != 0]
+                    fx_adjust = entry.clone().with_columns(
+                        currency=pl.lit(reporting_currency),
+                        report_amount=balance,
+                        amount=balance,
+                        id=pl.format("{}:fx", pl.col("id")),
+                        description=pl.format(
+                            "Currency adjustments: {}", pl.col("description"),
+                        ),
+                    )
+                    fx_adjust = fx_adjust.filter(
+                        pl.col("report_amount") != 0,
+                    )
                     fx_adjust = self._add_balancing_leg(
                         fx_adjust, fx_rate=1,
-                        account=transitory_account, currency=reporting_currency
+                        account=transitory_account,
+                        currency=reporting_currency,
                     )
 
-                    result = pd.concat(
-                        [self.journal.standardize(entry),
-                         self.journal.standardize(fx_adjust)], ignore_index=True
+                    result = pl.concat(
+                        [
+                            self.journal.standardize(entry, pandas=False),
+                            self.journal.standardize(
+                                fx_adjust, pandas=False,
+                            ),
+                        ],
+                        how="diagonal",
                     )
-                result["amount"] = self.round_to_precision(
-                    result["amount"], result["currency"]
+                result = result.with_columns(
+                    amount=pl.Series(self.round_to_precision(
+                        result["amount"], result["currency"],
+                    )),
+                    report_amount=pl.Series(self.round_to_precision(
+                        result["report_amount"],
+                        pl.Series([reporting_currency] * len(result)),
+                    )),
                 )
-                result["report_amount"] = self.round_to_precision(
-                    result["report_amount"], reporting_currency
-                )
+                account_present = result["account"].is_not_null()
+                contra_present = result["contra"].is_not_null()
                 multiplier = (
-                    result["account"].notna().astype(int)
-                    - result["contra"].notna().astype(int)
+                    account_present.cast(pl.Int64)
+                    - contra_present.cast(pl.Int64)
                 )
-                amount = np.where(
-                    result["currency"] == reporting_currency,
-                    result["amount"], result["report_amount"]
-                )
-                rounding_error = (multiplier * amount).sum(skipna=False)
+                amount_col = pl.when(
+                    pl.col("currency") == reporting_currency
+                ).then(pl.col("amount")).otherwise(pl.col("report_amount"))
+                amount_vals = result.select(
+                    val=amount_col
+                )["val"]
+                rounding_error = (multiplier * amount_vals).sum()
+
                 currency_precision = self.precision_vectorized(
-                    [currency], [entry["date"].iloc[0]]
+                    [currency], [entry["date"][0]],
                 )[0]
                 if abs(rounding_error) > currency_precision / 2:
-                    # Rounding after converting foreign currency amounts to reporting
-                    # currency amounts by multipying with FX rate leads to rounding
-                    # differences that sum up to a net rounding difference equal or
-                    # larger than currency precision (0.01 for CHF, EUR, USD, etc.).
+                    # Rounding after converting foreign currency amounts to
+                    # reporting currency amounts by multipying with FX rate
+                    # leads to rounding differences that sum up to a net
+                    # rounding difference equal or larger than currency
+                    # precision (0.01 for CHF, EUR, USD, etc.).
                     # -> We compensate this rounding difference by creating
-                    #    transactions that have rounding differences with the same
-                    #    amount but opposite sign.
+                    #    transactions that have rounding differences with the
+                    #    same amount but opposite sign.
                     # 1. Create a transaction with one cent rounding difference
-                    rounding_compensation = entry.to_dict("records")[0]
-                    txn_id = rounding_compensation["id"] + ":rounding"
-                    sign = np.sign(rounding_error)
-                    rounding_compensation |= {
-                        "description": "Compensation of CashCtrl rounding differences",
-                        "account": transitory_account,
-                        "currency": currency,
-                        "amount": [sign * x for x in [-0.01, -0.01, 0.02]],
-                        "report_amount": [sign * x for x in [-0.01, -0.01, 0.01]],
-                    }
+                    first_row = entry.row(0, named=True)
+                    txn_id = str(first_row["id"]) + ":rounding"
+                    sign = math.copysign(1, rounding_error)
+                    rounding_compensation = pl.DataFrame({
+                        "id": [txn_id] * 3,
+                        "date": [first_row["date"]] * 3,
+                        "description": [
+                            "Compensation of CashCtrl rounding differences"
+                        ] * 3,
+                        "account": [transitory_account] * 3,
+                        "currency": [currency] * 3,
+                        "amount": [
+                            sign * x for x in [-0.01, -0.01, 0.02]
+                        ],
+                        "report_amount": [
+                            sign * x for x in [-0.01, -0.01, 0.01]
+                        ],
+                    })
                     rounding_compensation = self.journal.standardize(
-                        pd.DataFrame(rounding_compensation)
+                        rounding_compensation, pandas=False,
                     )
-                    # 2. Duplicate this transaction as often as needed to compensate
-                    #    the full rounding error
-                    rounding_compensation = [
-                        rounding_compensation.assign(id=f"{txn_id}-{i}")
-                        for i in range(abs(round(rounding_error / currency_precision)))
+                    # 2. Duplicate this transaction as often as needed to
+                    #    compensate the full rounding error
+                    n_repeats = abs(
+                        round(rounding_error / currency_precision)
+                    )
+                    parts = [
+                        rounding_compensation.with_columns(
+                            id=pl.lit(f"{txn_id}-{i}"),
+                        )
+                        for i in range(n_repeats)
                     ]
-                    result = pd.concat(
-                        [result, *rounding_compensation], ignore_index=True
+                    result = pl.concat(
+                        [result, *parts], how="diagonal",
                     )
-                return self.journal.standardize(result)
+                return self.journal.standardize(result, pandas=False)
 
         else:
             raise ValueError("Expecting at least one `entry` row.")
 
-    def _add_balancing_leg(self, entry, fx_rate, account, currency):
-        multiplier = entry["account"].notna().astype(int) - entry["contra"].notna().astype(int)
-        balance = self.round_to_precision(-1.0 * (entry["amount"] * multiplier).sum(), currency)
+    def _add_balancing_leg(
+        self, entry: pl.DataFrame, fx_rate: float,
+        account: int, currency: str,
+    ) -> pl.DataFrame:
+        account_present = entry["account"].is_not_null().cast(pl.Int64)
+        contra_present = entry["contra"].is_not_null().cast(pl.Int64)
+        multiplier = account_present - contra_present
+        balance = self.round_to_precision(
+            -1.0 * (entry["amount"] * multiplier).sum(), currency,
+        )
         if balance != 0:
-            balancing_leg = entry.head(1).copy()
-            balancing_leg["currency"] = currency
-            balancing_leg["description"] = "Balancing foreign currency amount"
-            balancing_leg["amount"] = balance
-            balancing_leg["account"] = account
-            balancing_leg["report_amount"] = self.round_to_precision(
-                balancing_leg["amount"] * fx_rate, self.reporting_currency,
+            first_row = entry.head(1).clone()
+            balancing_leg = first_row.with_columns(
+                currency=pl.lit(currency),
+                description=pl.lit("Balancing foreign currency amount"),
+                amount=pl.lit(balance),
+                account=pl.lit(account),
+                report_amount=pl.lit(self.round_to_precision(
+                    balance * fx_rate, self.reporting_currency,
+                )),
             )
-            entry = pd.concat(
+            entry = pl.concat(
                 [
-                    self.journal.standardize(entry),
-                    self.journal.standardize(balancing_leg),
-                ]
+                    self.journal.standardize(entry, pandas=False),
+                    self.journal.standardize(balancing_leg, pandas=False),
+                ],
+                how="diagonal",
             )
         return entry

--- a/cashctrl_ledger/journal_entity.py
+++ b/cashctrl_ledger/journal_entity.py
@@ -1,6 +1,7 @@
 """Provides a class with Journal accessors and mutators for CashCtrl."""
 
 import pandas as pd
+import polars as pl
 from typing import Callable
 from pyledger import JournalEntity
 from .cashctrl_accounting_entity import CashCtrlAccountingEntity
@@ -17,26 +18,23 @@ class Journal(JournalEntity, CashCtrlAccountingEntity):
 
     def __init__(
         self,
-        list: Callable[[], pd.DataFrame],
-        add: Callable[[pd.DataFrame], None],
-        modify: Callable[[pd.DataFrame], None],
-        delete: Callable[[pd.DataFrame, bool], None],
-        standardize: Callable[[pd.DataFrame], pd.DataFrame],
+        list: Callable[..., pd.DataFrame | pl.DataFrame],
+        add: Callable[[pd.DataFrame | pl.DataFrame], None],
+        modify: Callable[[pd.DataFrame | pl.DataFrame], None],
+        delete: Callable[[pd.DataFrame | pl.DataFrame, bool], None],
+        standardize: Callable[[pd.DataFrame | pl.DataFrame], pd.DataFrame | pl.DataFrame],
         *args, **kwargs
     ):
         """
         Initializes the journal class.
 
         Args:
-            list (Callable[[], pd.DataFrame]):
-                A callable that lists journal entries and returns a DataFrame.
-            add (Callable[[pd.DataFrame], None]):
-                A callable that adds journal entries from a DataFrame.
-            modify (Callable[[pd.DataFrame], None]):
-                A callable that modifies journal entries based on a DataFrame.
-            delete (Callable[[pd.DataFrame, bool], None]):
-                A callable that deletes journal entries specified in a DataFrame.
-             *args, **kwargs: Additional arguments passed to the superclass.
+            list: A callable that lists journal entries and returns a DataFrame.
+            add: A callable that adds journal entries from a DataFrame.
+            modify: A callable that modifies journal entries based on a DataFrame.
+            delete: A callable that deletes journal entries specified in a DataFrame.
+            standardize: A callable that standardizes journal entries.
+            *args, **kwargs: Additional arguments passed to the superclass.
         """
         super().__init__(*args, **kwargs)
         self._list = list
@@ -45,18 +43,27 @@ class Journal(JournalEntity, CashCtrlAccountingEntity):
         self._delete = delete
         self._standardize = standardize
 
-    def list(self, fiscal_period: str | None = None) -> pd.DataFrame:
-        return self._list(fiscal_period=fiscal_period)
+    def list(
+        self, fiscal_period: str | None = None, pandas: bool = True,
+    ) -> pd.DataFrame | pl.DataFrame:
+        return self._list(fiscal_period=fiscal_period, pandas=pandas)
 
-    def add(self, data: pd.DataFrame) -> None:
+    def add(self, data: pd.DataFrame | pl.DataFrame) -> None:
         return self._add(data)
 
-    def modify(self, data: pd.DataFrame) -> None:
+    def modify(self, data: pd.DataFrame | pl.DataFrame) -> None:
         self._modify(data)
 
-    def delete(self, id: pd.DataFrame, allow_missing: bool = False) -> None:
+    def delete(self, id: pd.DataFrame | pl.DataFrame, allow_missing: bool = False) -> None:
         self._delete(id, allow_missing)
 
-    def standardize(self, data, keep_extra_columns=False):
-        data = super().standardize(data, keep_extra_columns)
-        return self._standardize(data)
+    def standardize(
+        self, data: pd.DataFrame | pl.DataFrame,
+        keep_extra_columns=False, pandas: bool = True,
+    ):
+        data = super().standardize(data, keep_extra_columns, pandas=False)
+        result = self._standardize(data)
+        if pandas:
+            from pyledger.schema import to_pandas
+            return to_pandas(result, self._schema)
+        return result

--- a/cashctrl_ledger/journal_entity.py
+++ b/cashctrl_ledger/journal_entity.py
@@ -4,6 +4,7 @@ import pandas as pd
 import polars as pl
 from typing import Callable
 from pyledger import JournalEntity
+from pyledger.schema import to_pandas
 from .cashctrl_accounting_entity import CashCtrlAccountingEntity
 
 
@@ -29,12 +30,15 @@ class Journal(JournalEntity, CashCtrlAccountingEntity):
         Initializes the journal class.
 
         Args:
-            list: A callable that lists journal entries and returns a DataFrame.
-            add: A callable that adds journal entries from a DataFrame.
-            modify: A callable that modifies journal entries based on a DataFrame.
-            delete: A callable that deletes journal entries specified in a DataFrame.
-            standardize: A callable that standardizes journal entries.
-            *args, **kwargs: Additional arguments passed to the superclass.
+            list (Callable[..., pd.DataFrame | pl.DataFrame]):
+                A callable that lists journal entries and returns a DataFrame.
+            add (Callable[[pd.DataFrame | pl.DataFrame], None]):
+                A callable that adds journal entries from a DataFrame.
+            modify (Callable[[pd.DataFrame | pl.DataFrame], None]):
+                A callable that modifies journal entries based on a DataFrame.
+            delete (Callable[[pd.DataFrame | pl.DataFrame, bool], None]):
+                A callable that deletes journal entries specified in a DataFrame.
+             *args, **kwargs: Additional arguments passed to the superclass.
         """
         super().__init__(*args, **kwargs)
         self._list = list
@@ -64,6 +68,5 @@ class Journal(JournalEntity, CashCtrlAccountingEntity):
         data = super().standardize(data, keep_extra_columns, pandas=False)
         result = self._standardize(data)
         if pandas:
-            from pyledger.schema import to_pandas
             return to_pandas(result, self._schema)
         return result

--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -5,8 +5,8 @@ import json
 from typing import Dict, List, Tuple
 import zipfile
 from cashctrl_api import CashCtrlClient
-import numpy as np
 import pandas as pd
+import polars as pl
 from pathlib import Path
 from cashctrl_ledger.profit_center import ProfitCenter
 from .tax_code import TaxCode
@@ -30,7 +30,7 @@ from .constants import (
     REPORT_ELEMENT,
     REPORTING_CURRENCY_TAG
 )
-from consistent_df import unnest, enforce_dtypes, enforce_schema
+from pyledger.schema import enforce_schema, ensure_polars, to_polars, to_pandas
 from pyledger.time import parse_date_span
 from difflib import get_close_matches
 
@@ -153,22 +153,30 @@ class CashCtrlLedger(LedgerEngine):
     def restore(
         self,
         configuration: dict | None = None,
-        tax_codes: pd.DataFrame | None = None,
-        accounts: pd.DataFrame | None = None,
-        price_history: pd.DataFrame | None = None,
-        journal: pd.DataFrame | None = None,
-        assets: pd.DataFrame | None = None,
-        profit_centers: pd.DataFrame | None = None,
+        tax_codes: pd.DataFrame | pl.DataFrame | None = None,
+        accounts: pd.DataFrame | pl.DataFrame | None = None,
+        price_history: pd.DataFrame | pl.DataFrame | None = None,
+        journal: pd.DataFrame | pl.DataFrame | None = None,
+        assets: pd.DataFrame | pl.DataFrame | None = None,
+        profit_centers: pd.DataFrame | pl.DataFrame | None = None,
     ):
         self.clear()
         if configuration is not None and "REPORTING_CURRENCY" in configuration:
             self.reporting_currency = configuration["REPORTING_CURRENCY"]
         if accounts is not None:
-            self.accounts.mirror(accounts.assign(tax_code=pd.NA), delete=True)
+            accounts_pl = ensure_polars(accounts, "CashCtrlLedger.restore")
+            if "group" in accounts_pl.columns:
+                accounts_pl = accounts_pl.with_columns(
+                    group=self.sanitize_account_groups(accounts_pl["group"])
+                )
+            self.accounts.mirror(
+                accounts_pl.with_columns(tax_code=pl.lit(None).cast(pl.String)),
+                delete=True,
+            )
         if tax_codes is not None:
             self.tax_codes.mirror(tax_codes, delete=True)
         if accounts is not None:
-            self.accounts.mirror(accounts, delete=True)
+            self.accounts.mirror(accounts_pl, delete=True)
         if configuration is not None:
             self.configuration_modify(configuration)
         if assets is not None:
@@ -185,8 +193,10 @@ class CashCtrlLedger(LedgerEngine):
         self.configuration_clear()
 
         # Manually reset accounts tax to none
-        accounts = self.accounts.list()
-        self.accounts.mirror(accounts.assign(tax_code=pd.NA))
+        accounts = self.accounts.list(pandas=False)
+        self.accounts.mirror(
+            accounts.with_columns(tax_code=pl.lit(None).cast(pl.String))
+        )
         self.tax_codes.mirror(None, delete=True)
         self.accounts.mirror(None, delete=True)
         self.profit_centers.mirror(None, delete=True)
@@ -244,7 +254,10 @@ class CashCtrlLedger(LedgerEngine):
     # ----------------------------------------------------------------------
     # Accounts
 
-    def sanitize_account_groups(self, groups: pd.Series) -> pd.Series:
+    def sanitize_account_groups(
+        self, groups: pd.Series | pl.Series,
+        pandas: bool = True,
+    ) -> pd.Series | pl.Series:
         """Ensure account groups start with a leading slash and a valid root node.
 
         Account categories in CashCtrl must be assigned to one of the pre-defined root nodes.
@@ -252,40 +265,47 @@ class CashCtrlLedger(LedgerEngine):
         cannot be deleted.
 
         Args:
-            groups (pd.Series): A pandas Series containing account group paths.
+            groups: A pandas or polars Series containing account group paths.
+            pandas: If True and input is pandas, return pandas Series.
 
         Returns:
-            pd.Series: Sanitized account group series.
+            Sanitized account group series.
         """
-        groups = groups.str.replace(r'^/', '', regex=True)
-        first_nodes = groups.str.replace(r'/.*', '', regex=True)
-        first_nodes = first_nodes.apply(
-            lambda g: get_close_matches(g, ACCOUNT_ROOT_CATEGORIES, cutoff=0)[0]
+        is_pandas = isinstance(groups, pd.Series)
+        values = groups.to_list()
+        result = []
+        for g in values:
+            if g is None or (is_pandas and pd.isna(g)):
+                result.append(None)
+                continue
+            stripped = g.lstrip("/")
+            first_node = stripped.split("/")[0] if "/" in stripped else stripped
+            matched = get_close_matches(first_node, ACCOUNT_ROOT_CATEGORIES, cutoff=0)[0]
+            rest = stripped[len(first_node):]
+            result.append("/" + matched + rest)
+
+        if is_pandas:
+            return pd.Series(result, index=groups.index, dtype="string[python]")
+        return pl.Series(groups.name, result, dtype=pl.String)
+
+    def sanitize_accounts(
+        self, df: pd.DataFrame | pl.DataFrame, tax_codes: pd.DataFrame | pl.DataFrame = None,
+        pandas: bool = True,
+    ) -> pd.DataFrame | pl.DataFrame:
+        df = ensure_polars(df, "CashCtrlLedger.sanitize_accounts")
+        df = df.with_columns(
+            group=self.sanitize_account_groups(df["group"])
         )
-        groups = groups.where(
-            groups.isna(),
-            "/" + first_nodes + groups.str.replace(r'^[^/]+', '', regex=True)
-        ).astype("string[python]")
+        return super().sanitize_accounts(df, tax_codes=tax_codes, pandas=pandas)
 
-        return groups
-
-    def sanitize_accounts(self, df: pd.DataFrame, tax_codes: pd.DataFrame = None) -> pd.DataFrame:
-        df["group"] = self.sanitize_account_groups(df["group"])
-        df = super().sanitize_accounts(df, tax_codes=tax_codes)
-        return df
-
-    def _account_balances(self, period: str) -> pd.DataFrame:
+    def _account_balances(self, period: str) -> pl.DataFrame:
         """Generate a report of account balances for a chosen period.
 
         Args:
             period (datetime.date | str): Target period for the report.
 
         Returns:
-            pd.DataFrame: With these columns:
-                - amount (float): Account balance.
-                - report_amount (float): Reporting balance.
-                - account (str): Account name.
-                - currency (str): Currency code.
+            pl.DataFrame: With columns: amount, report_amount, account, currency.
         """
         prefixes = tuple(ACCOUNT_CATEGORIES_NEED_TO_NEGATE)
 
@@ -304,85 +324,138 @@ class CashCtrlLedger(LedgerEngine):
                     raise ValueError(f"Unexpected data format at {path}.")
             return nodes
 
-        def fetch_element(element_id: int, end) -> pd.DataFrame:
+        def fetch_element(element_id: int, end) -> pl.DataFrame:
             resp = self._client.json_request(
                 "GET", "report/element/data.json",
                 params={"elementId": element_id, "startDate": datetime.date.min, "endDate": end},
             )
-            return enforce_schema(pd.DataFrame(extract_nodes(resp["data"])), REPORT_ELEMENT)
+            return enforce_schema(
+                to_polars(pd.DataFrame(extract_nodes(resp["data"]))), REPORT_ELEMENT,
+            )
 
-        def adjust_sign(values: pd.Series, paths: pd.Series) -> pd.Series:
-            return np.where(paths.str.startswith(prefixes), -values, values)
-
-        def fetch_balances(end) -> pd.DataFrame:
-            df = pd.concat([fetch_element(1, end), fetch_element(2, end)], ignore_index=True)
-            df = df[df["accountId"].notna()].copy()
-            df["account"] = df["accountId"].map(self._client.account_from_id)
-            df["currency"] = df["currencyCode"].fillna(self.reporting_currency)
-            df["amount"] = adjust_sign(df["endAmount2"], df["path"])
-            df["report_amount"] = adjust_sign(df["dcEndAmount2"], df["path"])
-            return df.loc[:, ["amount", "report_amount", "account", "currency"]]
+        def fetch_balances(end) -> pl.DataFrame:
+            df = pl.concat([fetch_element(1, end), fetch_element(2, end)], how="diagonal")
+            df = df.filter(pl.col("accountId").is_not_null())
+            account_map = {
+                id_val: self._client.account_from_id(id_val)
+                for id_val in df["accountId"].unique().to_list()
+            }
+            df = df.with_columns(
+                account=pl.col("accountId").replace_strict(account_map, default=None),
+                currency=pl.col("currencyCode").fill_null(self.reporting_currency),
+            )
+            # Adjust sign for liability/revenue accounts
+            negate = pl.col("path").str.starts_with(prefixes[0])
+            for prefix in prefixes[1:]:
+                negate = negate | pl.col("path").str.starts_with(prefix)
+            df = df.with_columns(
+                amount=pl.when(negate).then(-pl.col("endAmount2")).otherwise(pl.col("endAmount2")),
+                report_amount=pl.when(negate)
+                .then(-pl.col("dcEndAmount2")).otherwise(pl.col("dcEndAmount2")),
+            )
+            result = df.select("amount", "report_amount", "account", "currency")
+            return result.cast({
+                "account": pl.Int64, "amount": pl.Float64,
+                "report_amount": pl.Float64, "currency": pl.String,
+            })
 
         start, end = parse_date_span(period)
         balance = fetch_balances(end=end)
         if start is not None:
             start = start - datetime.timedelta(days=1)
             start_balance = fetch_balances(end=start)
-            balance = balance.merge(
-                start_balance, on="account", how="outer", suffixes=("", "_start")
+            balance = balance.join(
+                start_balance, on="account", how="full", coalesce=True,
+                suffix="_start", nulls_equal=True,
             )
-            balance["amount"] = balance["amount"].fillna(0) - \
-                balance["amount_start"].fillna(0)
-            balance["report_amount"] = balance["report_amount"].fillna(0) - \
-                balance["report_amount_start"].fillna(0)
-            balance.drop(columns=["amount_start", "report_amount_start"], inplace=True)
-        return balance.reset_index(drop=True)
+            balance = balance.with_columns(
+                amount=pl.col("amount").fill_null(0) - pl.col("amount_start").fill_null(0),
+                report_amount=pl.col("report_amount").fill_null(0)
+                - pl.col("report_amount_start").fill_null(0),
+            ).drop("amount_start", "report_amount_start", "currency_start")
+
+        return balance
 
     def account_balances(
-        self, df: pd.DataFrame, reporting_currency_only: bool = False
-    ) -> pd.DataFrame:
-        unique_periods = df["period"].unique()
+        self, df: pd.DataFrame | pl.DataFrame, reporting_currency_only: bool = False,
+        pandas: bool = True, **kwargs,
+    ) -> pd.DataFrame | pl.DataFrame:
+        df = ensure_polars(df, "CashCtrlLedger.account_balances")
+        unique_periods = df["period"].unique(maintain_order=True).to_list()
         balance_lookup = {p: self._account_balances(period=p) for p in unique_periods}
 
         def _calc_balances(period, account):
             balance = balance_lookup[period]
             _, end = parse_date_span(period)
             multipliers = self.account_multipliers(self.account_range(account, mode="parts"))
-            multipliers = pd.DataFrame(
-                list(multipliers.items()), columns=["account", "multiplier"]
+            mult_df = pl.DataFrame({
+                "account": list(multipliers.keys()),
+                "multiplier": list(multipliers.values()),
+            })
+            balance = balance.join(
+                mult_df, on="account", how="inner", nulls_equal=True,
             )
-            balance = balance.merge(multipliers, on="account", how="inner")
-            balance["amount"] *= balance["multiplier"]
-            balance["report_amount"] *= balance["multiplier"]
+            balance = balance.with_columns(
+                amount=pl.col("amount") * pl.col("multiplier"),
+                report_amount=pl.col("report_amount") * pl.col("multiplier"),
+            )
             report_balance = balance["report_amount"].sum()
-            report_balance = self.round_to_precision([report_balance], ["reporting_currency"])[0]
+            report_balance = self.round_to_precision(
+                [report_balance], ["reporting_currency"]
+            )[0]
 
             if reporting_currency_only:
                 return {"report_balance": report_balance}
 
-            balance = (
-                balance.groupby("currency", sort=False, observed=True)["amount"]
-                .sum()
-                .reset_index()
+            grouped = balance.group_by("currency").agg(
+                amount=pl.col("amount").sum()
             )
-            balance["amount"] = self.round_to_precision(
-                balance["amount"], balance["currency"], end
+            amounts = self.round_to_precision(
+                grouped["amount"], grouped["currency"], end
             )
+            balance_list = [
+                {"currency": c, "amount": a}
+                for c, a in zip(grouped["currency"].to_list(), amounts)
+            ]
             return {
                 "report_balance": report_balance,
-                "balance": dict(zip(balance["currency"], balance["amount"]))
+                "balance": balance_list if balance_list else None,
             }
 
         results = [
             _calc_balances(period=row["period"], account=row["account"])
-            for _, row in df.iterrows()
+            for row in df.iter_rows(named=True)
         ]
-        return pd.DataFrame(results)
+
+        balance_type = pl.List(pl.Struct({"currency": pl.String, "amount": pl.Float64}))
+        if not results:
+            cols = {"report_balance": pl.Float64}
+            if not reporting_currency_only:
+                cols["balance"] = balance_type
+            result = pl.DataFrame(schema=cols)
+        else:
+            result = pl.DataFrame(results)
+            if "balance" in result.columns:
+                result = result.cast({"balance": balance_type})
+
+        if pandas:
+            rows = []
+            for row_dict in result.iter_rows(named=True):
+                out = {"report_balance": row_dict["report_balance"]}
+                if not reporting_currency_only:
+                    out["balance"] = self._balance_list_to_dict(
+                        row_dict.get("balance")
+                    )
+                rows.append(out)
+            return pd.DataFrame(rows)
+        return result
 
     # ----------------------------------------------------------------------
     # Journal
 
-    def _journal_list(self, fiscal_period: str | None = None) -> pd.DataFrame:
+    def _journal_list(
+        self, fiscal_period: str | None = None, pandas: bool = True,
+    ) -> pd.DataFrame | pl.DataFrame:
         """Retrieves journal entries from the remote CashCtrl account.
 
         Args:
@@ -390,71 +463,88 @@ class CashCtrlLedger(LedgerEngine):
                 - `None` (default): Returns entries for all fiscal periods.
                 - `"current"`: Returns entries for the selected fiscal period.
                 - Any other string: Returns entries for the given fiscal period (e.g., `"2025"`).
+            pandas (bool): If True, return pandas DataFrame.
 
         Returns:
-            pd.DataFrame: A DataFrame following the `LedgerEngine.JOURNAL_SCHEMA` column schema.
+            DataFrame following the `LedgerEngine.JOURNAL_SCHEMA` column schema.
 
         Raises:
             ValueError: If the fiscal period does not exist or no current period is defined.
         """
         if fiscal_period is None:
-            ids = self.fiscal_period_list()["id"]
+            ids = self.fiscal_period_list(pandas=False)["id"].to_list()
         elif fiscal_period == "current":
             ids = [None]
         else:
             ids = [self._client.fiscal_period_to_id(fiscal_period)]
-        journal_entries = [self._client.list_journal_entries(fiscal_period_id=id) for id in ids]
-        return self._map_journal_entries(pd.concat(journal_entries, ignore_index=True))
+        journal_entries = []
+        for id in ids:
+            df = self._client.list_journal_entries(fiscal_period_id=id)
+            # Strip timezone before converting to polars to preserve local dates
+            if "dateAdded" in df.columns and hasattr(df["dateAdded"].dt, "tz"):
+                df["dateAdded"] = df["dateAdded"].dt.tz_localize(None)
+            journal_entries.append(to_polars(df))
+        result = self._map_journal_entries(pl.concat(journal_entries, how="diagonal"))
 
-    def _map_journal_entries(self, journal: pd.DataFrame) -> pd.DataFrame:
+        if pandas:
+            return to_pandas(result, self._journal._schema)
+        return result
+
+    def _map_journal_entries(self, journal: pl.DataFrame) -> pl.DataFrame:
         """Convert CashCtrl journal entries to pyledger format.
 
         Args:
-            journal (pd.DataFrame): Raw journal entries from CashCtrl.
+            journal (pl.DataFrame): Raw journal entries from CashCtrl.
 
         Returns:
-            pd.DataFrame: Standardized journal DataFrame following the
+            pl.DataFrame: Standardized journal DataFrame following the
                 `LedgerEngine.JOURNAL_SCHEMA` column schema.
         """
         # Individual ledger entries represent a single transaction and
         # map to a single row in the resulting data frame.
-        individual = journal[journal["type"] != "COLLECTIVE"]
+        individual = journal.filter(pl.col("type") != "COLLECTIVE")
 
         # Map to credit and debit account number and account currency
-        cols = {"id": "creditId", "currencyCode": "credit_currency", "number": "credit_account"}
-        account_map = self._client.list_accounts()[cols.keys()].rename(columns=cols)
-        individual = pd.merge(individual, account_map, "left", on="creditId", validate="m:1")
-        cols = {"id": "debitId", "currencyCode": "debit_currency", "number": "debit_account"}
-        account_map = self._client.list_accounts()[cols.keys()].rename(columns=cols)
-        individual = pd.merge(individual, account_map, "left", on="debitId", validate="m:1")
+        accounts = to_polars(self._client.list_accounts())
+        credit_map = accounts.select(
+            creditId=pl.col("id"),
+            credit_currency=pl.col("currencyCode"),
+            credit_account=pl.col("number"),
+        )
+        individual = individual.join(
+            credit_map, on="creditId", how="left", nulls_equal=True,
+        )
+        debit_map = accounts.select(
+            debitId=pl.col("id"),
+            debit_currency=pl.col("currencyCode"),
+            debit_account=pl.col("number"),
+        )
+        individual = individual.join(
+            debit_map, on="debitId", how="left", nulls_equal=True,
+        )
 
         # Identify foreign currency adjustment transactions
-        currency = individual["currencyCode"]
         reporting_currency = self.reporting_currency
         is_fx_adjustment = (
-            (currency == reporting_currency)
+            (pl.col("currencyCode") == reporting_currency)
             & (
-                (currency != individual["credit_currency"])
-                | (currency != individual["debit_currency"])
+                (pl.col("currencyCode") != pl.col("credit_currency"))
+                | (pl.col("currencyCode") != pl.col("debit_currency"))
             )
         )
-        currency = np.where(
-            is_fx_adjustment,
-            np.where(
-                individual["credit_currency"] != currency,
-                individual["credit_currency"],
-                individual["debit_currency"]
-            ),
-            currency
+        individual = individual.with_columns(
+            _is_fx=is_fx_adjustment,
+            _currency=pl.when(is_fx_adjustment).then(
+                pl.when(pl.col("credit_currency") != pl.col("currencyCode"))
+                .then(pl.col("credit_currency"))
+                .otherwise(pl.col("debit_currency"))
+            ).otherwise(pl.col("currencyCode")),
+            _amount=pl.when(is_fx_adjustment).then(0).otherwise(pl.col("amount")),
+            _reporting_amount=pl.col("amount") * pl.col("currencyRate"),
         )
-        amount = np.where(is_fx_adjustment, 0, individual["amount"])
-        reporting_amount = individual["amount"] * individual["currencyRate"]
 
-        def resolve_profit_center(raw_id: int | str | None) -> str | None:
-            """Resolve a profit center name from an integer or a list.
-            If the input is malformed, ambiguous (e.g. multiple IDs), or resolution fails,
-            a warning is logged and None is returned.
-            """
+        def resolve_profit_center(raw_id) -> str | None:
+            """Resolve a profit center name from an integer or a list."""
             result = None
             if raw_id is None:
                 return result
@@ -475,125 +565,166 @@ class CashCtrlLedger(LedgerEngine):
                     f"Failed to resolve profit center {raw_id}: {e}. "
                     "Setting profit center to None for this ledger entry."
                 )
-
             return result
 
-        profit_centers = individual["costCenterIds"].apply(resolve_profit_center)
-        result = pd.DataFrame(
-            {
-                "id": individual["id"],
-                "date": individual["dateAdded"].dt.date,
-                "account": individual["debit_account"],
-                "contra": individual["credit_account"],
-                "currency": currency,
-                "amount": self.round_to_precision(amount, currency),
-                "report_amount": self.round_to_precision(reporting_amount, reporting_currency),
-                "tax_code": individual["taxName"],
-                "profit_center": profit_centers,
-                "description": individual["title"],
-                "document": individual["reference"],
-            }
-        )
+        profit_centers = [
+            resolve_profit_center(v) for v in individual["costCenterIds"].to_list()
+        ]
+        currency_series = individual["_currency"]
+        amount_series = individual["_amount"]
+        reporting_amount_series = individual["_reporting_amount"]
+
+        result = pl.DataFrame({
+            "id": individual["id"],
+            "date": individual["dateAdded"].cast(pl.Date),
+            "account": individual["debit_account"],
+            "contra": individual["credit_account"],
+            "currency": currency_series,
+            "amount": self.round_to_precision(amount_series, currency_series),
+            "report_amount": self.round_to_precision(
+                reporting_amount_series,
+                pl.Series([reporting_currency] * len(reporting_amount_series)),
+            ),
+            "tax_code": individual["taxName"],
+            "profit_center": profit_centers,
+            "description": individual["title"],
+            "document": individual["reference"],
+        })
 
         # Collective journal entries represent a group of transactions and
         # map to multiple rows in the resulting data frame with the same id.
-        collective_ids = journal.loc[journal["type"] == "COLLECTIVE", "id"]
+        collective_ids = journal.filter(pl.col("type") == "COLLECTIVE")["id"].to_list()
         if len(collective_ids) > 0:
 
-            # Fetch individual legs (line 'items') of collective transaction
-            def fetch_journal(id: int) -> pd.DataFrame:
-                res = self._client.get("journal/read.json", params={"id": id})["data"]
-                return pd.DataFrame(
-                    {
-                        "id": [res["id"]],
+            # Fetch individual legs (line 'items') of collective transaction as flat rows
+            rows = []
+            for cid in collective_ids:
+                res = self._client.get("journal/read.json", params={"id": cid})["data"]
+                for item in res.get("items", []):
+                    row = {
+                        "id": res["id"],
                         "document": res["reference"],
-                        "date": [pd.to_datetime(res["dateAdded"]).date()],
-                        "currency": [res["currencyCode"]],
-                        "rate": [res["currencyRate"]],
-                        "items": [enforce_dtypes(pd.DataFrame(res["items"]), JOURNAL_ITEM_COLUMNS)],
-                        "fx_rate": [res["currencyRate"]],
+                        "date": datetime.date.fromisoformat(res["dateAdded"][:10]),
+                        "currency": res["currencyCode"],
+                        "fx_rate": res["currencyRate"],
                     }
-                )
-            dfs = pd.concat([fetch_journal(id) for id in collective_ids])
-            collective = unnest(dfs, "items")
+                    for col in JOURNAL_ITEM_COLUMNS:
+                        row[col] = item.get(col)
+                    row["allocations"] = item.get("allocations")
+                    rows.append(row)
+            if not rows:
+                return self.journal.standardize(result, pandas=False)
+            collective = to_polars(rows)
 
             # Map to account number and account currency
-            cols = {"id": "accountId", "currencyCode": "account_currency", "number": "account"}
-            account_map = self._client.list_accounts()[cols.keys()].rename(columns=cols)
-            collective = pd.merge(collective, account_map, "left", on="accountId", validate="m:1")
+            account_map = accounts.select(
+                accountId=pl.col("id"),
+                account_currency=pl.col("currencyCode"),
+                account=pl.col("number"),
+            )
+            collective = collective.join(
+                account_map, on="accountId", how="left", nulls_equal=True,
+            )
 
             # Identify reporting currency or foreign currency adjustment transactions
-            reporting_currency = self.reporting_currency
-            is_fx_adjustment = (collective["account_currency"] != reporting_currency) & (
-                collective["currency"].isna() | (collective["currency"] == reporting_currency)
+            is_fx_adjustment = (
+                (pl.col("account_currency") != reporting_currency)
+                & (pl.col("currency").is_null() | (pl.col("currency") == reporting_currency))
             )
 
-            amount = collective["debit"].fillna(0) - collective["credit"].fillna(0)
+            collective = collective.with_columns(
+                _amount=pl.col("debit").fill_null(0) - pl.col("credit").fill_null(0),
+            )
+
             # Use reporting currency if the row was tagged with REPORTING_CURRENCY_TAG,
             # else use transaction-level currency, and fallback to account currency.
-            # This recovers the original row-level currency intent lost during Cashctrl export.
-            currency = pd.Series(np.where(
-                collective["associateName"].fillna("") == REPORTING_CURRENCY_TAG,
-                reporting_currency,
-                collective["currency"]
-            ), index=collective.index).fillna(collective["account_currency"])
-            reporting_amount = np.where(
-                currency == reporting_currency,
-                pd.NA,
-                np.where(is_fx_adjustment, amount, amount * collective["fx_rate"]),
+            collective = collective.with_columns(
+                _currency=pl.when(
+                    pl.col("associateName").fill_null("") == REPORTING_CURRENCY_TAG
+                ).then(pl.lit(reporting_currency))
+                .otherwise(pl.col("currency"))
+                .fill_null(pl.col("account_currency")),
+                _is_fx=is_fx_adjustment,
             )
-            foreign_amount = np.where(
-                currency == reporting_currency,
-                amount * collective["fx_rate"],
-                np.where(is_fx_adjustment, 0, amount),
+
+            collective = collective.with_columns(
+                _reporting_amount=pl.when(pl.col("_currency") == reporting_currency)
+                .then(None)
+                .otherwise(
+                    pl.when(pl.col("_is_fx"))
+                    .then(pl.col("_amount"))
+                    .otherwise(pl.col("_amount") * pl.col("fx_rate"))
+                ),
+                _foreign_amount=pl.when(pl.col("_currency") == reporting_currency)
+                .then(pl.col("_amount") * pl.col("fx_rate"))
+                .otherwise(
+                    pl.when(pl.col("_is_fx")).then(0).otherwise(pl.col("_amount"))
+                ),
             )
-            profit_centers = collective["allocations"].apply(
-                lambda allocation: resolve_profit_center(allocation[0].get("toCostCenterId"))
-                if isinstance(allocation, list) and allocation else None
-            )
-            mapped_collective = pd.DataFrame({
+
+            profit_centers_col = []
+            for alloc in collective["allocations"].to_list():
+                if isinstance(alloc, list) and alloc:
+                    pc = resolve_profit_center(alloc[0].get("toCostCenterId"))
+                else:
+                    pc = None
+                profit_centers_col.append(pc)
+
+            currency_col = collective["_currency"]
+            foreign_amount_col = collective["_foreign_amount"]
+            reporting_amount_col = collective["_reporting_amount"]
+
+            mapped_collective = pl.DataFrame({
                 "id": collective["id"],
                 "date": collective["date"],
                 "account": collective["account"],
-                "currency": currency,
-                "amount": self.round_to_precision(foreign_amount, currency),
-                "report_amount": self.round_to_precision(reporting_amount, reporting_currency),
+                "currency": currency_col,
+                "amount": self.round_to_precision(foreign_amount_col, currency_col),
+                "report_amount": self.round_to_precision(
+                    reporting_amount_col,
+                    pl.Series([reporting_currency] * len(reporting_amount_col)),
+                ),
                 "tax_code": collective["taxName"],
-                "profit_center": profit_centers,
+                "profit_center": profit_centers_col,
                 "description": collective["description"],
                 "document": collective["document"],
             })
-            result = pd.concat([
-                self.journal.standardize(result),
-                self.journal.standardize(mapped_collective),
-            ])
+            result = pl.concat([
+                self.journal.standardize(result, pandas=False),
+                self.journal.standardize(mapped_collective, pandas=False),
+            ], how="diagonal")
 
-        return self.journal.standardize(result).reset_index(drop=True)
+        return self.journal.standardize(result, pandas=False)
 
     def journal_entry(self):
         """Not implemented yet."""
         raise NotImplementedError
 
-    def fiscal_period_list(self) -> pd.DataFrame:
+    def fiscal_period_list(self, pandas: bool = True) -> pd.DataFrame | pl.DataFrame:
         """Retrieve fiscal periods.
 
         Retrieve fiscal periods and check that each consecutive period
         starts exactly one day after the previous one ends.
 
         Returns:
-            pd.DataFrame: A DataFrame of fiscal periods with FISCAL_PERIOD_SCHEMA.
+            pd.DataFrame | pl.DataFrame: Fiscal periods with FISCAL_PERIOD_SCHEMA.
 
         Raises:
             Exception: If any gap is detected between consecutive fiscal periods.
         """
         fiscal_periods = self._client.list_fiscal_periods()
-        fp = enforce_schema(pd.DataFrame(fiscal_periods), FISCAL_PERIOD_SCHEMA)
+        fp = enforce_schema(to_polars(pd.DataFrame(fiscal_periods)), FISCAL_PERIOD_SCHEMA)
 
         # Calculate the gap between consecutive periods (next start - current end)
-        consecutive_gap = fp["start"].dt.date.shift(-1) - fp["end"].dt.date
-        if any(consecutive_gap[:-1] != pd.Timedelta(days=1)):
-            raise ValueError("Gaps between fiscal periods.")
+        starts = fp["start"].to_list()
+        ends = fp["end"].to_list()
+        for i in range(len(starts) - 1):
+            gap = starts[i + 1] - ends[i]
+            if gap != datetime.timedelta(days=1):
+                raise ValueError("Gaps between fiscal periods.")
 
+        if pandas:
+            return to_pandas(fp, FISCAL_PERIOD_SCHEMA)
         return fp
 
     def fiscal_period_add(self, start: datetime.date, end: datetime.date, name: str):
@@ -625,116 +756,158 @@ class CashCtrlLedger(LedgerEngine):
             start (datetime.date): Start of the date range to ensure coverage for.
             end (datetime.date): End of the date range to ensure coverage for.
         """
-        start = pd.to_datetime(start)
-        end = pd.to_datetime(end)
-        fiscal_periods = self.fiscal_period_list()
+        fiscal_periods = self.fiscal_period_list(pandas=False)
+
+        def _to_date(dt):
+            """Convert datetime to date if needed."""
+            return dt.date() if isinstance(dt, datetime.datetime) else dt
+
+        def _offset_year(dt, years):
+            """Offset a date by a number of years, handling leap year edge cases."""
+            try:
+                return dt.replace(year=dt.year + years)
+            except ValueError:
+                # Feb 29 in a leap year -> Feb 28 in a non-leap year
+                return dt.replace(year=dt.year + years, day=dt.day - 1)
 
         # Extend fiscal periods backward if needed
-        while start < fiscal_periods["start"].min():
-            earliest_start = fiscal_periods["start"].min()
+        while start < _to_date(fiscal_periods["start"].min()):
+            earliest_start = _to_date(fiscal_periods["start"].min())
             # The new fiscal period will be one year before the earliest start
-            new_end = earliest_start - pd.Timedelta(days=1)
-            new_start = earliest_start - pd.DateOffset(years=1)
+            new_end = earliest_start - datetime.timedelta(days=1)
+            new_start = _offset_year(earliest_start, -1)
             new_name = str(new_end.year)
-            self.fiscal_period_add(start=new_start.date(), end=new_end.date(), name=new_name)
-            fiscal_periods = self.fiscal_period_list()
+            self.fiscal_period_add(start=new_start, end=new_end, name=new_name)
+            fiscal_periods = self.fiscal_period_list(pandas=False)
 
         # Extend fiscal periods forward if needed
-        while end > fiscal_periods["end"].max():
-            latest_end = fiscal_periods["end"].max()
+        while end > _to_date(fiscal_periods["end"].max()):
+            latest_end = _to_date(fiscal_periods["end"].max())
             # The new fiscal period will be one year after the latest end
-            new_start = latest_end + pd.Timedelta(days=1)
-            new_end = latest_end + pd.DateOffset(years=1)
+            new_start = latest_end + datetime.timedelta(days=1)
+            new_end = _offset_year(latest_end, 1)
             new_name = str(new_end.year)
-            self.fiscal_period_add(start=new_start.date(), end=new_end.date(), name=new_name)
-            fiscal_periods = self.fiscal_period_list()
+            self.fiscal_period_add(start=new_start, end=new_end, name=new_name)
+            fiscal_periods = self.fiscal_period_list(pandas=False)
 
-    def _journal_add(self, data: pd.DataFrame) -> str:
+    def _journal_add(self, data: pd.DataFrame | pl.DataFrame) -> str:
         ids = []
-        incoming = self.journal.standardize(data)
+        incoming = self.journal.standardize(data, pandas=False)
         self.ensure_fiscal_periods_exist(incoming["date"].min(), incoming["date"].max())
-        for id in incoming["id"].unique():
-            entry = incoming.query("id == @id")
+        for id in incoming["id"].unique(maintain_order=True).to_list():
+            entry = incoming.filter(pl.col("id") == id)
             payload = self._map_journal_entry(entry)
             res = self._client.post("journal/create.json", data=payload)
             ids.append(str(res["insertId"]))
             self._client.list_journal_entries.cache_clear()
         return ids
 
-    def _journal_modify(self, data: pd.DataFrame):
-        incoming = self.journal.standardize(data)
+    def _journal_modify(self, data: pd.DataFrame | pl.DataFrame):
+        incoming = self.journal.standardize(data, pandas=False)
         self.ensure_fiscal_periods_exist(incoming["date"].min(), incoming["date"].max())
-        for id in incoming["id"].unique():
-            entry = incoming.query("id == @id")
+        for id in incoming["id"].unique(maintain_order=True).to_list():
+            entry = incoming.filter(pl.col("id") == id)
             payload = self._map_journal_entry(entry)
             payload["id"] = id
             self._client.post("journal/update.json", data=payload)
             self._client.list_journal_entries.cache_clear()
 
-    def _journal_delete(self, id: pd.DataFrame, allow_missing=False):
-        incoming = enforce_schema(pd.DataFrame(id), JOURNAL_SCHEMA.query("id"))
+    def _journal_delete(self, id: pd.DataFrame | pl.DataFrame, allow_missing=False):
+        incoming = enforce_schema(
+            ensure_polars(id, "CashCtrlLedger._journal_delete"),
+            self._journal._schema.filter(pl.col("id")),
+        )
         self._client.post(
-            "journal/delete.json", {"ids": ",".join([str(id) for id in incoming["id"]])}
+            "journal/delete.json",
+            {"ids": ",".join([str(i) for i in incoming["id"].to_list()])}
         )
         self._client.list_journal_entries.cache_clear()
 
-    def _journal_standardize(self, df: pd.DataFrame) -> pd.DataFrame:
+    def _journal_standardize(self, df: pd.DataFrame | pl.DataFrame) -> pl.DataFrame:
         """Standardizes the journal DataFrame to conform to CashCtrl format.
 
         Args:
-            journal (pd.DataFrame): The journal DataFrame to be standardized.
+            df (pd.DataFrame | pl.DataFrame): The journal DataFrame to be standardized.
 
         Returns:
-            pd.DataFrame: The standardized journal DataFrame.
+            pl.DataFrame: The standardized journal DataFrame.
         """
+        df = ensure_polars(df, "CashCtrlLedger._journal_standardize")
+
+        # Normalize NaN to null on float columns
+        df = df.with_columns(
+            pl.col("amount").fill_nan(None),
+            pl.col("report_amount").fill_nan(None),
+        )
+
         # Drop redundant report_amount for transactions in reporting currency
         set_na = (
-            (df["currency"] == self.reporting_currency)
-            & (df["report_amount"].isna() | (df["report_amount"] == df["amount"]))
+            (pl.col("currency") == self.reporting_currency)
+            & (pl.col("report_amount").is_null()
+               | (pl.col("report_amount") == pl.col("amount")))
         )
-        df.loc[set_na, "report_amount"] = pd.NA
+        df = df.with_columns(
+            report_amount=pl.when(set_na).then(None).otherwise(pl.col("report_amount"))
+        )
 
         # In CashCtrl, attachments are stored at the transaction level rather than
         # for each individual line item within collective transactions. To ensure
         # consistency between equivalent transactions, we fill any missing (NA)
         # document paths with non-missing paths from other line items in the same
         # transaction.
-        df["document"] = df.groupby("id")["document"].ffill()
-        df["document"] = df.groupby("id")["document"].bfill()
+        df = df.with_columns(
+            document=pl.col("document").forward_fill().over("id")
+        )
+        df = df.with_columns(
+            document=pl.col("document").backward_fill().over("id")
+        )
 
         # Split collective transaction line items with both debit and credit into
         # two items with a single account each
-        is_collective = df["id"].duplicated(keep=False)
+        is_collective = pl.col("id").is_duplicated()
         items_to_split = (
-            is_collective & df["account"].notna() & df["contra"].notna()
+            is_collective & pl.col("account").is_not_null() & pl.col("contra").is_not_null()
         )
-        if items_to_split.any():
-            new = df.loc[items_to_split].copy()
-            new["account"] = new["contra"]
-            new.loc[:, "contra"] = pd.NA
-            for col in ["amount", "report_amount"]:
-                new[col] = np.where(
-                    new[col].isna() | (new[col] == 0), new[col], -1 * new[col]
-                )
-            df.loc[items_to_split, "contra"] = pd.NA
-            df = pd.concat([df, new])
+        split_mask = df.select(items_to_split).to_series()
+        if split_mask.any():
+            new = df.filter(split_mask)
+            new = new.with_columns(
+                account=pl.col("contra"),
+                contra=pl.lit(None).cast(pl.Int64),
+                amount=pl.when(
+                    pl.col("amount").is_null() | (pl.col("amount") == 0)
+                ).then(pl.col("amount")).otherwise(-1 * pl.col("amount")),
+                report_amount=pl.when(
+                    pl.col("report_amount").is_null() | (pl.col("report_amount") == 0)
+                ).then(pl.col("report_amount")).otherwise(-1 * pl.col("report_amount")),
+            )
+            df = df.with_columns(
+                contra=pl.when(items_to_split)
+                .then(pl.lit(None).cast(pl.Int64))
+                .otherwise(pl.col("contra"))
+            )
+            df = pl.concat([df, new], how="diagonal")
 
         # TODO: move this code block to parent class
         # Swap accounts if a contra but no account is provided,
         # or if individual transaction amount is negative
-        swap_accounts = df["contra"].notna() & (
-            (df["amount"] < 0) | (df["report_amount"] < 0) | df["account"].isna()
+        swap_accounts = pl.col("contra").is_not_null() & (
+            (pl.col("amount") < 0) | (pl.col("report_amount") < 0) | pl.col("account").is_null()
         )
-        if swap_accounts.any():
-            initial_account = df.loc[swap_accounts, "account"]
-            df.loc[swap_accounts, "account"] = df.loc[
-                swap_accounts, "contra"
-            ]
-            df.loc[swap_accounts, "contra"] = initial_account
-            df.loc[swap_accounts, "amount"] = -1 * df.loc[swap_accounts, "amount"]
-            df.loc[swap_accounts, "report_amount"] = (
-                -1 * df.loc[swap_accounts, "report_amount"]
+        swap_mask = df.select(swap_accounts).to_series()
+        if swap_mask.any():
+            df = df.with_columns(
+                _orig_account=pl.col("account"),
             )
+            df = df.with_columns(
+                account=pl.when(swap_accounts).then(pl.col("contra")).otherwise(pl.col("account")),
+                contra=pl.when(swap_accounts)
+                .then(pl.col("_orig_account")).otherwise(pl.col("contra")),
+                amount=pl.when(swap_accounts).then(-1 * pl.col("amount"))
+                .otherwise(pl.col("amount")),
+                report_amount=pl.when(swap_accounts).then(-1 * pl.col("report_amount"))
+                .otherwise(pl.col("report_amount")),
+            ).drop("_orig_account")
 
         return df
 
@@ -753,27 +926,21 @@ class CashCtrlLedger(LedgerEngine):
         """
         # Map journal entries to their actual and targeted attachments
         attachments = self._get_journal_attachments()
-        journal = self._client.list_journal_entries()
-        journal["id"] = journal["id"].astype("string[python]")
-        journal["reference"] = "/" + journal["reference"]
-        files = self._client.list_files()
-        df = pd.DataFrame(
-            {
-                "journal": journal["id"],
-                "target_attachment": np.where(
-                    journal["reference"].isin(files["path"]), journal["reference"], pd.NA
-                ),
-                "actual_attachments": [
-                    attachments.get(id, []) for id in journal["id"]
-                ],
-            }
+        journal = to_polars(self._client.list_journal_entries())
+        journal = journal.with_columns(
+            id=pl.col("id").cast(pl.String),
+            reference=pl.lit("/") + pl.col("reference"),
         )
+        files = to_polars(self._client.list_files())
+        file_paths = files["path"].to_list()
 
-        # Update attachments to align with the target attachments
-        for id, target, actual in zip(
-            df["journal"], df["target_attachment"], df["actual_attachments"]
-        ):
-            if pd.isna(target):
+        for row in journal.iter_rows(named=True):
+            id = row["id"]
+            reference = row["reference"]
+            actual = attachments.get(id, [])
+            target = reference if reference in file_paths else None
+
+            if target is None:
                 if actual and detach:
                     self._client.post(
                         "journal/update_attachments.json", data={"id": id, "fileIds": ""}
@@ -797,9 +964,10 @@ class CashCtrlLedger(LedgerEngine):
             Dict[str, List[str]]: A Dict that contains journal ids with attached
             files as keys and a list of file paths as values.
         """
-        journal = self._client.list_journal_entries()
+        journal = to_polars(self._client.list_journal_entries())
         result = {}
-        for id in journal.loc[journal["attachmentCount"] > 0, "id"]:
+        has_attachments = journal.filter(pl.col("attachmentCount") > 0)
+        for id in has_attachments["id"].to_list():
             res = self._client.get("journal/read.json", params={"id": id})["data"]
             paths = [
                 self._client.file_id_to_path(
@@ -811,7 +979,9 @@ class CashCtrlLedger(LedgerEngine):
                 result[str(id)] = paths
         return result
 
-    def _collective_transaction_currency_and_rate(self, entry: pd.DataFrame) -> Tuple[str, float]:
+    def _collective_transaction_currency_and_rate(
+        self, entry: pd.DataFrame | pl.DataFrame,
+    ) -> Tuple[str, float]:
         """Extract a single currency and exchange rate from a collective transaction in pyledger
         format.
 
@@ -837,9 +1007,8 @@ class CashCtrlLedger(LedgerEngine):
         format.
 
         Args:
-            entry (pd.DataFrame): The DataFrame representing individual entries of a collective
-                                  transaction with columns 'currency', 'amount',
-                                  and 'report_amount'.
+            entry (pd.DataFrame | pl.DataFrame): The DataFrame representing individual entries of
+                a collective transaction with columns 'currency', 'amount', and 'report_amount'.
 
         Returns:
             Tuple[str, float]: The single currency and the corresponding exchange rate.
@@ -848,35 +1017,38 @@ class CashCtrlLedger(LedgerEngine):
             ValueError: If more than one non-reporting currency is present or if no
                         coherent exchange rate is found.
         """
-        if not isinstance(entry, pd.DataFrame) or entry.empty:
-            raise ValueError("`entry` must be a pd.DataFrame with at least one row.")
+        entry = ensure_polars(entry, "CashCtrlLedger._collective_transaction_currency_and_rate")
+        if len(entry) == 0:
+            raise ValueError("`entry` must be a DataFrame with at least one row.")
         if "id" in entry.columns:
-            id = entry["id"].iat[0]
+            id = entry["id"][0]
         else:
             id = ""
         expected_columns = ["currency", "amount", "report_amount"]
-        if not set(expected_columns).issubset(entry.columns):
-            missing = [col for col in expected_columns if col not in entry.columns]
+        missing = [col for col in expected_columns if col not in entry.columns]
+        if missing:
             raise ValueError(f"Missing required column(s) {missing}: {id}.")
 
         # Check if all entries are denominated in reporting currency
         reporting_currency = self.reporting_currency
         is_reporting_txn = (
-            entry["currency"].isna()
-            | (entry["currency"] == reporting_currency)
-            | (entry["amount"] == 0)
+            pl.col("currency").is_null()
+            | (pl.col("currency") == reporting_currency)
+            | (pl.col("amount") == 0)
         )
-        if all(is_reporting_txn):
+        entry = entry.with_columns(_is_reporting=is_reporting_txn)
+        if entry["_is_reporting"].all():
             return reporting_currency, 1.0
 
         # Extract the sole non-reporting currency
-        fx_entries = entry.loc[~is_reporting_txn]
-        if fx_entries["currency"].nunique() != 1:
+        fx_entries = entry.filter(~pl.col("_is_reporting"))
+        unique_currencies = fx_entries["currency"].unique().to_list()
+        if len(unique_currencies) != 1:
             raise ValueError(
                 "CashCtrl allows only the reporting currency plus a single foreign currency in "
                 f"a collective booking: {id}."
             )
-        currency = fx_entries["currency"].iat[0]
+        currency = unique_currencies[0]
 
         # Define precision parameters for exchange rate calculation
         precision = self.precision_vectorized([reporting_currency], [None])[0]
@@ -884,18 +1056,22 @@ class CashCtrlLedger(LedgerEngine):
 
         # Calculate the range of acceptable exchange rates
         reporting_amount = fx_entries["report_amount"]
-        tolerance = (fx_entries["amount"] * fx_rate_precision).clip(lower=precision / 2)
-        lower_bound = reporting_amount - tolerance * np.where(reporting_amount < 0, -1, 1)
-        upper_bound = reporting_amount + tolerance * np.where(reporting_amount < 0, -1, 1)
-        min_fx_rate = (lower_bound / fx_entries["amount"]).max()
-        max_fx_rate = (upper_bound / fx_entries["amount"]).min()
+        amount = fx_entries["amount"]
+        tolerance = (amount * fx_rate_precision).abs().clip(precision / 2, float("inf"))
+        sign = pl.Series(
+            [(-1 if x < 0 else 1) for x in reporting_amount.to_list()], dtype=pl.Int8,
+        )
+        lower_bound = reporting_amount - tolerance * sign
+        upper_bound = reporting_amount + tolerance * sign
+        min_fx_rate = (lower_bound / amount).max()
+        max_fx_rate = (upper_bound / amount).min()
 
         # Select the exchange rate within the acceptable range closest to the preferred rate
         # derived from the largest absolute amount
-        max_abs_amount = fx_entries["amount"].abs().max()
-        is_max_abs = fx_entries["amount"].abs() == max_abs_amount
-        fx_rates = fx_entries["report_amount"] / fx_entries["amount"]
-        preferred_rate = fx_rates.loc[is_max_abs].median()
+        max_abs_amount = amount.abs().max()
+        is_max_abs = amount.abs() == max_abs_amount
+        fx_rates = reporting_amount / amount
+        preferred_rate = fx_rates.filter(is_max_abs).median()
         if min_fx_rate <= max_fx_rate:
             fx_rate = min(max(preferred_rate, min_fx_rate), max_fx_rate)
         else:
@@ -903,56 +1079,51 @@ class CashCtrlLedger(LedgerEngine):
 
         return currency, fx_rate
 
-    def _map_journal_entry(self, entry: pd.DataFrame) -> dict:
+    def _map_journal_entry(self, entry: pd.DataFrame | pl.DataFrame) -> dict:
         """Converts a single journal entry to a data structure for upload to CashCtrl.
 
         Args:
-            entry (pd.DataFrame): DataFrame with journal entry in pyledger schema.
+            entry (pd.DataFrame | pl.DataFrame): DataFrame with journal entry in pyledger schema.
 
         Returns:
             dict: A data structure to post as json to the CashCtrl REST API.
         """
-        entry = self.journal.standardize(entry)
+        entry = self.journal.standardize(entry, pandas=False)
         reporting_currency = self.reporting_currency
 
         # Individual journal entry
         if len(entry) == 1:
-            amount = entry["amount"].iat[0]
-            reporting_amount = entry["report_amount"].iat[0]
-            currency = entry["currency"].iat[0]
-            if amount == 0 and not pd.isna(reporting_amount) and reporting_amount != 0:
+            row = entry.row(0, named=True)
+            amount = row["amount"]
+            reporting_amount = row["report_amount"]
+            currency = row["currency"]
+            if amount == 0 and reporting_amount is not None and reporting_amount != 0:
                 # Foreign currency adjustment: Solely changes in reporting currency amount
                 currency = reporting_currency
                 amount = reporting_amount
                 fx_rate = 1
             else:
-                amount = entry["amount"].iat[0]
                 if currency == self.reporting_currency or amount == 0:
                     fx_rate = 1
+                elif reporting_amount is None:
+                    fx_rate = None
                 else:
                     fx_rate = reporting_amount / amount
-            if pd.isna(entry["profit_center"].iat[0]):
-                profit_center = None
-            else:
-                profit_center = self._client.profit_center_to_id(entry["profit_center"].iat[0])
+            profit_center = None if row["profit_center"] is None else \
+                self._client.profit_center_to_id(row["profit_center"])
             payload = {
-                "dateAdded": entry["date"].iat[0],
+                "dateAdded": row["date"],
                 "amount": amount,
-                "debitId": self._client.account_to_id(entry["account"].iat[0]),
-                "creditId": self._client.account_to_id(entry["contra"].iat[0]),
-                "currencyId": None
-                if pd.isna(currency)
+                "debitId": self._client.account_to_id(row["account"]),
+                "creditId": self._client.account_to_id(row["contra"]),
+                "currencyId": None if currency is None
                 else self._client.currency_to_id(currency),
-                "title": entry["description"].iat[0],
-                "taxId": None
-                if pd.isna(entry["tax_code"].iat[0])
-                else self._client.tax_code_to_id(entry["tax_code"].iat[0]),
+                "title": row["description"],
+                "taxId": None if row["tax_code"] is None
+                else self._client.tax_code_to_id(row["tax_code"]),
                 "currencyRate": fx_rate,
-                "reference": None
-                if pd.isna(entry["document"].iat[0])
-                else entry["document"].iat[0],
-                "allocations": None
-                if profit_center is None
+                "reference": row["document"],
+                "allocations": None if profit_center is None
                 else [{"share": 1.0, "toCostCenterId": profit_center}],
             }
 
@@ -961,7 +1132,7 @@ class CashCtrlLedger(LedgerEngine):
             # Individual transaction entries (line items)
             items = []
             currency, fx_rate = self._collective_transaction_currency_and_rate(entry)
-            for _, row in entry.iterrows():
+            for row in entry.iter_rows(named=True):
                 if row["currency"] == currency:
                     amount = row["amount"]
                 elif currency == reporting_currency:
@@ -974,17 +1145,14 @@ class CashCtrlLedger(LedgerEngine):
                         "allowed in CashCtrl collective transactions."
                     )
                 amount = self.round_to_precision(amount, currency)
-                if pd.isna(row["profit_center"]):
-                    profit_center = None
-                else:
-                    profit_center = self._client.profit_center_to_id(row["profit_center"])
+                profit_center = None if row["profit_center"] is None else \
+                    self._client.profit_center_to_id(row["profit_center"])
                 items.append(
                     {
                         "accountId": self._client.account_to_id(row["account"]),
                         "credit": -amount if amount < 0 else None,
                         "debit": amount if amount >= 0 else None,
-                        "taxId": None
-                        if pd.isna(row["tax_code"])
+                        "taxId": None if row["tax_code"] is None
                         else self._client.tax_code_to_id(row["tax_code"]),
                         "description": row["description"],
                         # Use the associateId field (not its original purpose) to tag the row if
@@ -993,27 +1161,27 @@ class CashCtrlLedger(LedgerEngine):
                         "associateId": REPORTING_CURRENCY_TAG
                         if (row["currency"] != currency) and (row["currency"] == reporting_currency)
                         else None,
-                        "allocations": None
-                        if profit_center is None
+                        "allocations": None if profit_center is None
                         else [{"share": 1.0, "toCostCenterId": profit_center}],
                     }
                 )
 
             # Transaction-level attributes
-            date = entry["date"].dropna().unique()
-            document = entry["document"].dropna().unique()
-            if len(date) == 0:
+            dates = entry["date"].drop_nulls().unique().to_list()
+            documents = entry["document"].drop_nulls().unique().to_list()
+            if len(dates) == 0:
                 raise ValueError("Date is not specified in collective booking.")
-            elif len(date) > 1:
+            elif len(dates) > 1:
                 raise ValueError("Date needs to be unique in a collective booking.")
-            if len(document) > 1:
+            if len(documents) > 1:
                 raise ValueError(
                     "CashCtrl allows only one reference in a collective booking."
                 )
             payload = {
-                "dateAdded": date[0].strftime("%Y-%m-%d"),
+                "dateAdded": dates[0].strftime("%Y-%m-%d")
+                if isinstance(dates[0], (datetime.date, datetime.datetime)) else str(dates[0]),
                 "currencyId": self._client.currency_to_id(currency),
-                "reference": document[0] if len(document) == 1 else None,
+                "reference": documents[0] if len(documents) == 1 else None,
                 "currencyRate": fx_rate,
                 "items": items,
             }
@@ -1031,11 +1199,12 @@ class CashCtrlLedger(LedgerEngine):
         Returns:
             str: The reporting currency code.
         """
-        currencies = self._client.list_currencies()
-        is_reporting_currency = currencies["isDefault"].astype("bool")
-        if is_reporting_currency.sum() == 1:
-            return currencies.loc[is_reporting_currency, "code"].item()
-        elif is_reporting_currency.sum() == 0:
+        currencies = to_polars(self._client.list_currencies())
+        is_reporting = currencies["isDefault"].cast(pl.Boolean)
+        reporting = currencies.filter(is_reporting)
+        if len(reporting) == 1:
+            return reporting["code"][0]
+        elif len(reporting) == 0:
             raise ValueError("No reporting currency set.")
         else:
             raise ValueError("Multiple reporting currencies defined.")
@@ -1043,15 +1212,16 @@ class CashCtrlLedger(LedgerEngine):
     @reporting_currency.setter
     def reporting_currency(self, currency):
         # TODO: Perform testing of this method after restore() for currencies implemented
-        currencies = self._client.list_currencies()
-        if currency in set(currencies["code"]):
-            target_currency = currencies[currencies["code"] == currency].iloc[0]
+        currencies = to_polars(self._client.list_currencies())
+        matching = currencies.filter(pl.col("code") == currency)
+        if len(matching) > 0:
+            target = matching.row(0, named=True)
             payload = {
-                "id": target_currency["id"],
+                "id": target["id"],
                 "code": currency,
                 "isDefault": True,
-                "description": target_currency["description"],
-                "rate": target_currency["rate"]
+                "description": target["description"],
+                "rate": target["rate"]
             }
             self._client.post("currency/update.json", data=payload)
         else:
@@ -1074,8 +1244,10 @@ class CashCtrlLedger(LedgerEngine):
 
     def _ensure_currencies_exist(self):
         """Ensure all local asset tickers definitions exist remotely"""
-        local = set(self.assets.list()["ticker"].dropna())
-        remote = set(self._client.list_currencies()["code"].dropna())
+        local_assets = self.assets.list(pandas=False)
+        local = set(local_assets["ticker"].drop_nulls().to_list())
+        remote_currencies = to_polars(self._client.list_currencies())
+        remote = set(remote_currencies["code"].drop_nulls().to_list())
         to_add = local - remote
 
         for currency in to_add:

--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -167,7 +167,9 @@ class CashCtrlLedger(LedgerEngine):
             accounts_pl = ensure_polars(accounts, "CashCtrlLedger.restore")
             if "group" in accounts_pl.columns:
                 accounts_pl = accounts_pl.with_columns(
-                    group=self.sanitize_account_groups(accounts_pl["group"])
+                    group=self.sanitize_account_groups(
+                        accounts_pl["group"], pandas=False,
+                    )
                 )
             self.accounts.mirror(
                 accounts_pl.with_columns(tax_code=pl.lit(None).cast(pl.String)),
@@ -265,17 +267,21 @@ class CashCtrlLedger(LedgerEngine):
         cannot be deleted.
 
         Args:
-            groups: A pandas or polars Series containing account group paths.
+            groups (pd.Series | pl.Series): A pandas or polars Series containing account group
+                paths.
             pandas: If True and input is pandas, return pandas Series.
 
         Returns:
-            Sanitized account group series.
+            pd.Series | pl.Series: Sanitized account group series.
         """
-        is_pandas = isinstance(groups, pd.Series)
+        original_index = None
+        if isinstance(groups, pd.Series):
+            original_index = groups.index
+            groups = pl.Series(groups.name, groups.to_list(), dtype=pl.String)
         values = groups.to_list()
         result = []
         for g in values:
-            if g is None or (is_pandas and pd.isna(g)):
+            if g is None:
                 result.append(None)
                 continue
             stripped = g.lstrip("/")
@@ -284,8 +290,10 @@ class CashCtrlLedger(LedgerEngine):
             rest = stripped[len(first_node):]
             result.append("/" + matched + rest)
 
-        if is_pandas:
-            return pd.Series(result, index=groups.index, dtype="string[python]")
+        if pandas:
+            return pd.Series(
+                result, index=original_index, dtype="string[python]",
+            )
         return pl.Series(groups.name, result, dtype=pl.String)
 
     def sanitize_accounts(
@@ -294,7 +302,7 @@ class CashCtrlLedger(LedgerEngine):
     ) -> pd.DataFrame | pl.DataFrame:
         df = ensure_polars(df, "CashCtrlLedger.sanitize_accounts")
         df = df.with_columns(
-            group=self.sanitize_account_groups(df["group"])
+            group=self.sanitize_account_groups(df["group"], pandas=False)
         )
         return super().sanitize_accounts(df, tax_codes=tax_codes, pandas=pandas)
 
@@ -305,7 +313,11 @@ class CashCtrlLedger(LedgerEngine):
             period (datetime.date | str): Target period for the report.
 
         Returns:
-            pl.DataFrame: With columns: amount, report_amount, account, currency.
+            pl.DataFrame: With these columns:
+                - amount (float): Account balance.
+                - report_amount (float): Reporting balance.
+                - account (str): Account name.
+                - currency (str): Currency code.
         """
         prefixes = tuple(ACCOUNT_CATEGORIES_NEED_TO_NEGATE)
 
@@ -330,7 +342,7 @@ class CashCtrlLedger(LedgerEngine):
                 params={"elementId": element_id, "startDate": datetime.date.min, "endDate": end},
             )
             return enforce_schema(
-                to_polars(pd.DataFrame(extract_nodes(resp["data"]))), REPORT_ELEMENT,
+                pl.DataFrame(extract_nodes(resp["data"])), REPORT_ELEMENT,
             )
 
         def fetch_balances(end) -> pl.DataFrame:
@@ -466,7 +478,8 @@ class CashCtrlLedger(LedgerEngine):
             pandas (bool): If True, return pandas DataFrame.
 
         Returns:
-            DataFrame following the `LedgerEngine.JOURNAL_SCHEMA` column schema.
+            pd.DataFrame | pl.DataFrame: A DataFrame following the
+                `LedgerEngine.JOURNAL_SCHEMA` column schema.
 
         Raises:
             ValueError: If the fiscal period does not exist or no current period is defined.
@@ -543,8 +556,11 @@ class CashCtrlLedger(LedgerEngine):
             _reporting_amount=pl.col("amount") * pl.col("currencyRate"),
         )
 
-        def resolve_profit_center(raw_id) -> str | None:
-            """Resolve a profit center name from an integer or a list."""
+        def resolve_profit_center(raw_id: int | str | None) -> str | None:
+            """Resolve a profit center name from an integer or a list.
+            If the input is malformed, ambiguous (e.g. multiple IDs), or resolution fails,
+            a warning is logged and None is returned.
+            """
             result = None
             if raw_id is None:
                 return result
@@ -638,6 +654,7 @@ class CashCtrlLedger(LedgerEngine):
 
             # Use reporting currency if the row was tagged with REPORTING_CURRENCY_TAG,
             # else use transaction-level currency, and fallback to account currency.
+            # This recovers the original row-level currency intent lost during Cashctrl export.
             collective = collective.with_columns(
                 _currency=pl.when(
                     pl.col("associateName").fill_null("") == REPORTING_CURRENCY_TAG
@@ -707,20 +724,22 @@ class CashCtrlLedger(LedgerEngine):
         starts exactly one day after the previous one ends.
 
         Returns:
-            pd.DataFrame | pl.DataFrame: Fiscal periods with FISCAL_PERIOD_SCHEMA.
+            pd.DataFrame | pl.DataFrame: A DataFrame of fiscal periods with
+                FISCAL_PERIOD_SCHEMA.
 
         Raises:
             Exception: If any gap is detected between consecutive fiscal periods.
         """
         fiscal_periods = self._client.list_fiscal_periods()
-        fp = enforce_schema(to_polars(pd.DataFrame(fiscal_periods)), FISCAL_PERIOD_SCHEMA)
+        fp = enforce_schema(pl.DataFrame(fiscal_periods), FISCAL_PERIOD_SCHEMA)
 
         # Calculate the gap between consecutive periods (next start - current end)
-        starts = fp["start"].to_list()
-        ends = fp["end"].to_list()
-        for i in range(len(starts) - 1):
-            gap = starts[i + 1] - ends[i]
-            if gap != datetime.timedelta(days=1):
+        if len(fp) > 1:
+            gaps = (
+                fp["start"].shift(-1).slice(0, len(fp) - 1)
+                - fp["end"].slice(0, len(fp) - 1)
+            )
+            if (gaps != datetime.timedelta(days=1)).any():
                 raise ValueError("Gaps between fiscal periods.")
 
         if pandas:
@@ -794,8 +813,7 @@ class CashCtrlLedger(LedgerEngine):
         ids = []
         incoming = self.journal.standardize(data, pandas=False)
         self.ensure_fiscal_periods_exist(incoming["date"].min(), incoming["date"].max())
-        for id in incoming["id"].unique(maintain_order=True).to_list():
-            entry = incoming.filter(pl.col("id") == id)
+        for entry in incoming.partition_by("id", maintain_order=True):
             payload = self._map_journal_entry(entry)
             res = self._client.post("journal/create.json", data=payload)
             ids.append(str(res["insertId"]))
@@ -934,6 +952,7 @@ class CashCtrlLedger(LedgerEngine):
         files = to_polars(self._client.list_files())
         file_paths = files["path"].to_list()
 
+        # Update attachments to align with the target attachments
         for row in journal.iter_rows(named=True):
             id = row["id"]
             reference = row["reference"]
@@ -1058,9 +1077,9 @@ class CashCtrlLedger(LedgerEngine):
         reporting_amount = fx_entries["report_amount"]
         amount = fx_entries["amount"]
         tolerance = (amount * fx_rate_precision).abs().clip(precision / 2, float("inf"))
-        sign = pl.Series(
-            [(-1 if x < 0 else 1) for x in reporting_amount.to_list()], dtype=pl.Int8,
-        )
+        sign = pl.select(
+            pl.when(reporting_amount < 0).then(pl.lit(-1)).otherwise(pl.lit(1))
+        ).to_series().cast(pl.Int8)
         lower_bound = reporting_amount - tolerance * sign
         upper_bound = reporting_amount + tolerance * sign
         min_fx_rate = (lower_bound / amount).max()
@@ -1167,21 +1186,21 @@ class CashCtrlLedger(LedgerEngine):
                 )
 
             # Transaction-level attributes
-            dates = entry["date"].drop_nulls().unique().to_list()
-            documents = entry["document"].drop_nulls().unique().to_list()
-            if len(dates) == 0:
+            date = entry["date"].drop_nulls().unique().to_list()
+            document = entry["document"].drop_nulls().unique().to_list()
+            if len(date) == 0:
                 raise ValueError("Date is not specified in collective booking.")
-            elif len(dates) > 1:
+            elif len(date) > 1:
                 raise ValueError("Date needs to be unique in a collective booking.")
-            if len(documents) > 1:
+            if len(document) > 1:
                 raise ValueError(
                     "CashCtrl allows only one reference in a collective booking."
                 )
             payload = {
-                "dateAdded": dates[0].strftime("%Y-%m-%d")
-                if isinstance(dates[0], (datetime.date, datetime.datetime)) else str(dates[0]),
+                "dateAdded": date[0].strftime("%Y-%m-%d")
+                if isinstance(date[0], (datetime.date, datetime.datetime)) else str(date[0]),
                 "currencyId": self._client.currency_to_id(currency),
-                "reference": documents[0] if len(documents) == 1 else None,
+                "reference": document[0] if len(document) == 1 else None,
                 "currencyRate": fx_rate,
                 "items": items,
             }
@@ -1200,8 +1219,8 @@ class CashCtrlLedger(LedgerEngine):
             str: The reporting currency code.
         """
         currencies = to_polars(self._client.list_currencies())
-        is_reporting = currencies["isDefault"].cast(pl.Boolean)
-        reporting = currencies.filter(is_reporting)
+        is_reporting_currency = currencies["isDefault"].cast(pl.Boolean)
+        reporting = currencies.filter(is_reporting_currency)
         if len(reporting) == 1:
             return reporting["code"][0]
         elif len(reporting) == 0:
@@ -1215,13 +1234,13 @@ class CashCtrlLedger(LedgerEngine):
         currencies = to_polars(self._client.list_currencies())
         matching = currencies.filter(pl.col("code") == currency)
         if len(matching) > 0:
-            target = matching.row(0, named=True)
+            target_currency = matching.row(0, named=True)
             payload = {
-                "id": target["id"],
+                "id": target_currency["id"],
                 "code": currency,
                 "isDefault": True,
-                "description": target["description"],
-                "rate": target["rate"]
+                "description": target_currency["description"],
+                "rate": target_currency["rate"]
             }
             self._client.post("currency/update.json", data=payload)
         else:

--- a/cashctrl_ledger/profit_center.py
+++ b/cashctrl_ledger/profit_center.py
@@ -1,38 +1,51 @@
 """Provides a class with profit_center accessors and mutators for CashCtrl."""
 
 import pandas as pd
-from consistent_df import enforce_schema
+import polars as pl
+from pyledger.schema import enforce_schema, ensure_polars, to_polars
 from .cashctrl_accounting_entity import CashCtrlAccountingEntity
 
 
 class ProfitCenter(CashCtrlAccountingEntity):
     """Provides profit center accessors and mutators for CashCtrl."""
 
-    def list(self) -> pd.DataFrame:
-        profit_centers = self._client.list_profit_centers()
-        result = pd.DataFrame({
+    def list(self, pandas: bool = True) -> pd.DataFrame | pl.DataFrame:
+        profit_centers = to_polars(self._client.list_profit_centers())
+        result = pl.DataFrame({
             "profit_center": profit_centers["name"],
         })
 
-        duplicates = set(result.loc[result["profit_center"].duplicated(), "profit_center"])
-        if duplicates:
+        duplicated = result.filter(
+            result["profit_center"].is_duplicated()
+        )["profit_center"].unique().to_list()
+        if duplicated:
             raise ValueError(
                 "Duplicated profit centers in the remote system: "
-                f"'{', '.join(map(str, duplicates))}'"
+                f"'{', '.join(map(str, duplicated))}'"
             )
-        return self.standardize(result).reset_index(drop=True)
+        result = self.standardize(result, pandas=False)
 
-    def add(self, data: pd.DataFrame) -> None:
-        incoming = self.standardize(pd.DataFrame(data))
-        profit_centers = self._client.list_profit_centers()
-        if profit_centers["number"].empty:
+        if pandas:
+            from pyledger.schema import to_pandas
+            return to_pandas(result, self._schema)
+        return result
+
+    def add(self, data: pd.DataFrame | pl.DataFrame) -> None:
+        incoming = self.standardize(
+            ensure_polars(data, "ProfitCenter.add"), pandas=False,
+        )
+        profit_centers = to_polars(self._client.list_profit_centers())
+        if len(profit_centers) == 0 or profit_centers["number"].null_count() == len(profit_centers):
             start_number = 1
         else:
             start_number = profit_centers["number"].max() + 1
-        for offset, (_, row) in enumerate(incoming.iterrows()):
-            if row["profit_center"] in profit_centers["name"].values:
+
+        existing_names = profit_centers["name"].to_list()
+        for offset, row in enumerate(incoming.iter_rows(named=True)):
+            if row["profit_center"] in existing_names:
                 raise ValueError(
-                    f"Profit center already exists in the remote system: '{row['profit_center']}'."
+                    f"Profit center already exists in the remote system: "
+                    f"'{row['profit_center']}'."
                 )
             payload = {
                 "name": row["profit_center"],
@@ -41,18 +54,23 @@ class ProfitCenter(CashCtrlAccountingEntity):
             self._client.post("account/costcenter/create.json", data=payload)
         self._client.list_profit_centers.cache_clear()
 
-    def modify(self, data: pd.DataFrame) -> None:
+    def modify(self, data: pd.DataFrame | pl.DataFrame) -> None:
         raise NotImplementedError(
             "Profit center modification is not supported."
         )
 
-    def delete(self, id: pd.DataFrame, allow_missing: bool = False) -> None:
-        incoming = enforce_schema(pd.DataFrame(id), self._schema.query("id"))
+    def delete(self, id: pd.DataFrame | pl.DataFrame, allow_missing: bool = False) -> None:
+        incoming = enforce_schema(
+            ensure_polars(id, "ProfitCenter.delete"),
+            self._schema.filter(pl.col("id")),
+        )
         ids = []
-        for profit_center in incoming["profit_center"]:
-            id = self._client.profit_center_to_id(profit_center, allow_missing=allow_missing)
-            if id:
-                ids.append(str(id))
+        for profit_center in incoming["profit_center"].to_list():
+            remote_id = self._client.profit_center_to_id(
+                profit_center, allow_missing=allow_missing
+            )
+            if remote_id:
+                ids.append(str(remote_id))
         if len(ids):
             self._client.post("account/costcenter/delete.json", {"ids": ", ".join(ids)})
             self._client.list_profit_centers.cache_clear()

--- a/cashctrl_ledger/profit_center.py
+++ b/cashctrl_ledger/profit_center.py
@@ -2,7 +2,7 @@
 
 import pandas as pd
 import polars as pl
-from pyledger.schema import enforce_schema, ensure_polars, to_polars
+from pyledger.schema import enforce_schema, ensure_polars, to_pandas, to_polars
 from .cashctrl_accounting_entity import CashCtrlAccountingEntity
 
 
@@ -15,18 +15,17 @@ class ProfitCenter(CashCtrlAccountingEntity):
             "profit_center": profit_centers["name"],
         })
 
-        duplicated = result.filter(
+        duplicates = result.filter(
             result["profit_center"].is_duplicated()
         )["profit_center"].unique().to_list()
-        if duplicated:
+        if duplicates:
             raise ValueError(
                 "Duplicated profit centers in the remote system: "
-                f"'{', '.join(map(str, duplicated))}'"
+                f"'{', '.join(map(str, duplicates))}'"
             )
         result = self.standardize(result, pandas=False)
 
         if pandas:
-            from pyledger.schema import to_pandas
             return to_pandas(result, self._schema)
         return result
 
@@ -66,11 +65,11 @@ class ProfitCenter(CashCtrlAccountingEntity):
         )
         ids = []
         for profit_center in incoming["profit_center"].to_list():
-            remote_id = self._client.profit_center_to_id(
+            id = self._client.profit_center_to_id(
                 profit_center, allow_missing=allow_missing
             )
-            if remote_id:
-                ids.append(str(remote_id))
+            if id:
+                ids.append(str(id))
         if len(ids):
             self._client.post("account/costcenter/delete.json", {"ids": ", ".join(ids)})
             self._client.list_profit_centers.cache_clear()

--- a/cashctrl_ledger/tax_code.py
+++ b/cashctrl_ledger/tax_code.py
@@ -2,7 +2,7 @@
 
 import pandas as pd
 import polars as pl
-from pyledger.schema import enforce_schema, ensure_polars, to_polars
+from pyledger.schema import enforce_schema, ensure_polars, to_pandas, to_polars
 from .cashctrl_accounting_entity import CashCtrlAccountingEntity
 
 
@@ -25,15 +25,14 @@ class TaxCode(CashCtrlAccountingEntity):
             "is_inclusive": ~tax_rates["isGrossCalcType"],
         })
 
-        duplicated = result.filter(result["id"].is_duplicated())["id"].unique().to_list()
-        if duplicated:
+        duplicates = result.filter(result["id"].is_duplicated())["id"].unique().to_list()
+        if duplicates:
             raise ValueError(
-                f"Duplicated tax codes in the remote system: '{', '.join(map(str, duplicated))}'"
+                f"Duplicated tax codes in the remote system: '{', '.join(map(str, duplicates))}'"
             )
         result = self.standardize(result, pandas=False)
 
         if pandas:
-            from pyledger.schema import to_pandas
             return to_pandas(result, self._schema)
         return result
 
@@ -91,9 +90,9 @@ class TaxCode(CashCtrlAccountingEntity):
         )
         ids = []
         for code in incoming["id"].to_list():
-            remote_id = self._client.tax_code_to_id(code, allow_missing=allow_missing)
-            if remote_id:
-                ids.append(str(remote_id))
+            id = self._client.tax_code_to_id(code, allow_missing=allow_missing)
+            if id:
+                ids.append(str(id))
         if len(ids):
             self._client.post("tax/delete.json", {"ids": ", ".join(ids)})
             self._client.list_tax_rates.cache_clear()

--- a/cashctrl_ledger/tax_code.py
+++ b/cashctrl_ledger/tax_code.py
@@ -1,38 +1,50 @@
 """Provides a class with tax_code accessors and mutators for CashCtrl."""
 
 import pandas as pd
-from consistent_df import enforce_schema
+import polars as pl
+from pyledger.schema import enforce_schema, ensure_polars, to_polars
 from .cashctrl_accounting_entity import CashCtrlAccountingEntity
 
 
 class TaxCode(CashCtrlAccountingEntity):
     """Provides tax code accessors and mutators for CashCtrl."""
 
-    def list(self) -> pd.DataFrame:
-        tax_rates = self._client.list_tax_rates()
-        accounts = self._client.list_accounts()
-        account_map = accounts.set_index("id")["number"].to_dict()
-        if not tax_rates["accountId"].isin(account_map).all():
+    def list(self, pandas: bool = True) -> pd.DataFrame | pl.DataFrame:
+        tax_rates = to_polars(self._client.list_tax_rates())
+        accounts = to_polars(self._client.list_accounts())
+        account_map = dict(accounts.select("id", "number").iter_rows())
+        if not tax_rates["accountId"].is_in(list(account_map.keys())).all():
             raise ValueError("Unknown 'accountId' in CashCtrl tax rates.")
-        result = pd.DataFrame({
+        result = pl.DataFrame({
             "id": tax_rates["name"],
             "description": tax_rates["documentName"],
-            "account": tax_rates["accountId"].map(account_map),
+            "account": tax_rates["accountId"].replace_strict(
+                account_map, default=None
+            ),
             "rate": tax_rates["percentage"] / 100,
             "is_inclusive": ~tax_rates["isGrossCalcType"],
         })
 
-        duplicates = set(result.loc[result["id"].duplicated(), "id"])
-        if duplicates:
+        duplicated = result.filter(result["id"].is_duplicated())["id"].unique().to_list()
+        if duplicated:
             raise ValueError(
-                f"Duplicated tax codes in the remote system: '{', '.join(map(str, duplicates))}'"
+                f"Duplicated tax codes in the remote system: '{', '.join(map(str, duplicated))}'"
             )
-        return self.standardize(result)
+        result = self.standardize(result, pandas=False)
 
-    def add(self, data: pd.DataFrame) -> None:
-        incoming = self.standardize(pd.DataFrame(data))
-        incoming["is_inclusive"] = incoming["is_inclusive"].fillna(False)
-        for _, row in incoming.iterrows():
+        if pandas:
+            from pyledger.schema import to_pandas
+            return to_pandas(result, self._schema)
+        return result
+
+    def add(self, data: pd.DataFrame | pl.DataFrame) -> None:
+        incoming = self.standardize(
+            ensure_polars(data, "TaxCode.add"), pandas=False,
+        )
+        incoming = incoming.with_columns(
+            is_inclusive=pl.col("is_inclusive").fill_null(False)
+        )
+        for row in incoming.iter_rows(named=True):
             self._client.account_to_id(row["account"])
             payload = {
                 "name": row["id"],
@@ -44,20 +56,21 @@ class TaxCode(CashCtrlAccountingEntity):
             self._client.post("tax/create.json", data=payload)
         self._client.list_tax_rates.cache_clear()
 
-    def modify(self, data: pd.DataFrame) -> None:
-        data = pd.DataFrame(data)
-        cols = set(self._schema["column"]).intersection(data.columns)
-        cols = cols.union(self._schema.query("id")["column"])
-        reduced_schema = self._schema.query("column in @cols")
+    def modify(self, data: pd.DataFrame | pl.DataFrame) -> None:
+        data = ensure_polars(data, "TaxCode.modify")
+        schema_cols = self._schema["column"].to_list()
+        id_cols = self._schema.filter(pl.col("id"))["column"].to_list()
+        cols = list(set(schema_cols).intersection(data.columns).union(set(id_cols)))
+        reduced_schema = self._schema.filter(pl.col("column").is_in(cols))
         incoming = enforce_schema(data, reduced_schema, keep_extra_columns=True)
-        current = self.list()
+        current = self.list(pandas=False)
 
-        for _, row in incoming.iterrows():
+        for row in incoming.iter_rows(named=True):
             # Specify required fields for CashCtrl
-            existing = current.query("id == @row['id']")
-            rate = row["rate"] if "rate" in incoming.columns else existing["rate"].item()
+            existing = current.filter(pl.col("id") == row["id"])
+            rate = row["rate"] if "rate" in incoming.columns else existing["rate"][0]
             account = row["account"] if "account" in incoming.columns else \
-                existing["account"].item()
+                existing["account"][0]
             payload = {"id": self._client.tax_code_to_id(row["id"])}
             payload["name"] = row["id"]
             payload["percentage"] = rate * 100
@@ -71,13 +84,16 @@ class TaxCode(CashCtrlAccountingEntity):
             self._client.post("tax/update.json", data=payload)
         self._client.list_tax_rates.cache_clear()
 
-    def delete(self, id: pd.DataFrame, allow_missing: bool = False) -> None:
-        incoming = enforce_schema(pd.DataFrame(id), self._schema.query("id"))
+    def delete(self, id: pd.DataFrame | pl.DataFrame, allow_missing: bool = False) -> None:
+        incoming = enforce_schema(
+            ensure_polars(id, "TaxCode.delete"),
+            self._schema.filter(pl.col("id")),
+        )
         ids = []
-        for code in incoming["id"]:
-            id = self._client.tax_code_to_id(code, allow_missing=allow_missing)
-            if id:
-                ids.append(str(id))
+        for code in incoming["id"].to_list():
+            remote_id = self._client.tax_code_to_id(code, allow_missing=allow_missing)
+            if remote_id:
+                ids.append(str(remote_id))
         if len(ids):
             self._client.post("tax/delete.json", {"ids": ", ".join(ids)})
             self._client.list_tax_rates.cache_clear()


### PR DESCRIPTION
### Summary

- Migrate all internal computation from pandas to polars across entity classes (`accounts.py`, `tax_code.py`, `profit_center.py`, `journal_entity.py`), schema definitions (`constants.py`), and core ledger logic (`ledger.py`, `extended_ledger.py`)
- Public methods retain `pandas=True` flag for backward compatibility — callers get pandas DataFrames by default, polars with `pandas=False`
- Uses `ensure_polars()` at entry points and `to_pandas()` at exits, consistent with pyledger polars branch conventions
- Polars-native patterns: `when/then/otherwise`, `partition_by`, `scatter`, `pl.concat(how="diagonal")`, `replace_strict`
- CI updated to install pyledger from polars branch when on polars-related branches

### Test plan

- [x] All 102 tests pass (5 skipped) against live CashCtrl API (alex49 org)
- [x] flake8 clean
- [x] Imports verified
- [x] Restore script runs successfully

Depends on [pyledger polars branch](https://github.com/macxred/pyledger/tree/polars).