### PR TITLE
feat: adapt TaxCode to CashCtrl API 2.3.0 (polars port of #146)

### DIFF
--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -25,12 +25,12 @@
 
       steps:
         - name: Check out repository
-          uses: actions/checkout@v4
+          uses: actions/checkout@v6
           with:
             ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
         - name: Set up Python
-          uses: actions/setup-python@v4
+          uses: actions/setup-python@v6
           with:
             python-version: "3.x"
 

--- a/.github/workflows/restore-defaults.yml
+++ b/.github/workflows/restore-defaults.yml
@@ -33,10 +33,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -25,12 +25,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -36,12 +36,12 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           ref: ${{ github.event.pull_request.head.sha || github.ref }}
 
       - name: Set up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: "3.x"
 
@@ -59,15 +59,7 @@ jobs:
         run: pip install git+https://x-access-token:${{ secrets.PYLEDGER_CI_ACCESS_TOKEN }}@github.com/macxred/pyledger.git@${{ steps.pyledger-branch.outputs.ref }}
 
       - name: Install dependencies
-        run: pip install coverage pytest setuptools .
+        run: pip install pytest setuptools .
 
-      - name: Run tests with coverage
-        run: coverage run -m pytest -W error
-
-      - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v4
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: ./coverage.xml
-          flags: unittests
-          name: codecov-upload
+      - name: Run tests
+        run: python -m pytest -W error

--- a/cashctrl_ledger/accounts.py
+++ b/cashctrl_ledger/accounts.py
@@ -5,6 +5,7 @@ import pandas as pd
 import polars as pl
 from pyledger.schema import enforce_schema, ensure_polars, to_pandas, to_polars
 from .cashctrl_accounting_entity import CashCtrlAccountingEntity
+from .tax_code import extract_pyledger_id, cashctrl_tax_code
 
 
 class Account(CashCtrlAccountingEntity):
@@ -12,11 +13,16 @@ class Account(CashCtrlAccountingEntity):
 
     def list(self, pandas: bool = True) -> pd.DataFrame | pl.DataFrame:
         accounts = to_polars(self._client.list_accounts())
+        tax_rates = to_polars(self._client.list_tax_rates())
+        tax_code_map = {
+            tr["code"]: extract_pyledger_id(tr["description"], tr["code"])
+            for tr in tax_rates.iter_rows(named=True)
+        }
         result = pl.DataFrame({
             "account": accounts["number"],
             "currency": accounts["currencyCode"],
             "description": accounts["name"],
-            "tax_code": accounts["taxName"],
+            "tax_code": accounts["taxCode"].replace(tax_code_map),
             "group": accounts["path"],
         })
         result = self.standardize(result, pandas=False)
@@ -49,7 +55,7 @@ class Account(CashCtrlAccountingEntity):
                 "currencyId": self._client.currency_to_id(row["currency"]),
                 "name": row["description"],
                 "taxId": None if row["tax_code"] is None
-                else self._client.tax_code_to_id(row["tax_code"]),
+                else self._client.tax_code_to_id(cashctrl_tax_code(row["tax_code"])),
                 "categoryId": self._client.account_category_to_id(row["group"]),
             }
             self._client.post("account/create.json", data=payload)
@@ -88,7 +94,7 @@ class Account(CashCtrlAccountingEntity):
                 payload["name"] = row["description"]
             if "tax_code" in incoming.columns:
                 payload["taxId"] = None if row["tax_code"] is None else \
-                    self._client.tax_code_to_id(row["tax_code"])
+                    self._client.tax_code_to_id(cashctrl_tax_code(row["tax_code"]))
             self._client.post("account/update.json", data=payload)
         self._client.list_accounts.cache_clear()
 

--- a/cashctrl_ledger/constants.py
+++ b/cashctrl_ledger/constants.py
@@ -5,7 +5,7 @@ from pyledger.schema import read_schema as _read_schema_pl
 
 JOURNAL_ITEM_COLUMNS = [
     "accountId", "description", "debit", "credit",
-    "taxName", "associateName",
+    "taxCode", "associateName",
 ]
 
 

--- a/cashctrl_ledger/ledger.py
+++ b/cashctrl_ledger/ledger.py
@@ -9,7 +9,7 @@ import pandas as pd
 import polars as pl
 from pathlib import Path
 from cashctrl_ledger.profit_center import ProfitCenter
-from .tax_code import TaxCode
+from .tax_code import TaxCode, extract_pyledger_id, cashctrl_tax_code
 from .accounts import Account
 from .journal_entity import Journal
 from pyledger import LedgerEngine, CSVAccountingEntity
@@ -513,6 +513,14 @@ class CashCtrlLedger(LedgerEngine):
             pl.DataFrame: Standardized journal DataFrame following the
                 `LedgerEngine.JOURNAL_SCHEMA` column schema.
         """
+        # Reverse-map CashCtrl tax code strings back to pyledger ids. The adapter
+        # embeds the original pyledger id as a `[id]:...` prefix in description.
+        tax_rates = to_polars(self._client.list_tax_rates())
+        tax_code_map = {
+            tr["code"]: extract_pyledger_id(tr["description"], tr["code"])
+            for tr in tax_rates.iter_rows(named=True)
+        }
+
         # Individual ledger entries represent a single transaction and
         # map to a single row in the resulting data frame.
         individual = journal.filter(pl.col("type") != "COLLECTIVE")
@@ -601,7 +609,7 @@ class CashCtrlLedger(LedgerEngine):
                 reporting_amount_series,
                 pl.Series([reporting_currency] * len(reporting_amount_series)),
             ),
-            "tax_code": individual["taxName"],
+            "tax_code": individual["taxCode"].replace(tax_code_map),
             "profit_center": profit_centers,
             "description": individual["title"],
             "document": individual["reference"],
@@ -701,7 +709,7 @@ class CashCtrlLedger(LedgerEngine):
                     reporting_amount_col,
                     pl.Series([reporting_currency] * len(reporting_amount_col)),
                 ),
-                "tax_code": collective["taxName"],
+                "tax_code": collective["taxCode"].replace(tax_code_map),
                 "profit_center": profit_centers_col,
                 "description": collective["description"],
                 "document": collective["document"],
@@ -1139,7 +1147,7 @@ class CashCtrlLedger(LedgerEngine):
                 else self._client.currency_to_id(currency),
                 "title": row["description"],
                 "taxId": None if row["tax_code"] is None
-                else self._client.tax_code_to_id(row["tax_code"]),
+                else self._client.tax_code_to_id(cashctrl_tax_code(row["tax_code"])),
                 "currencyRate": fx_rate,
                 "reference": row["document"],
                 "allocations": None if profit_center is None
@@ -1172,7 +1180,7 @@ class CashCtrlLedger(LedgerEngine):
                         "credit": -amount if amount < 0 else None,
                         "debit": amount if amount >= 0 else None,
                         "taxId": None if row["tax_code"] is None
-                        else self._client.tax_code_to_id(row["tax_code"]),
+                        else self._client.tax_code_to_id(cashctrl_tax_code(row["tax_code"])),
                         "description": row["description"],
                         # Use the associateId field (not its original purpose) to tag the row if
                         # the original currency is the reporting currency. This helps recover

--- a/cashctrl_ledger/tax_code.py
+++ b/cashctrl_ledger/tax_code.py
@@ -1,34 +1,102 @@
 """Provides a class with tax_code accessors and mutators for CashCtrl."""
 
+import re
 import pandas as pd
 import polars as pl
 from pyledger.schema import enforce_schema, ensure_polars, to_pandas, to_polars
 from .cashctrl_accounting_entity import CashCtrlAccountingEntity
 
 
+# Round-trip encoding: the adapter prefixes the original pyledger id into the
+# CashCtrl description so ids with non-alphanumeric chars (e.g. IN_STD) survive
+# CashCtrl's alphanumeric-only `code` constraint.
+_DESCRIPTION_RE = re.compile(r"^\[([^\]]+)\]:(.*)", re.DOTALL)
+
+
+def cashctrl_tax_code(pyledger_id: str) -> str:
+    """Convert a pyledger tax code id into CashCtrl's stored alphanumeric form."""
+    return re.sub(r"[^A-Za-z0-9]", "", str(pyledger_id)).upper()
+
+
+def extract_pyledger_id(description, code: str) -> str:
+    """Return the pyledger id from a `[id]:...` prefix, or fall back to `code`."""
+    pyledger_id = code
+    if description is not None and not pd.isna(description):
+        match = _DESCRIPTION_RE.match(str(description))
+        if match:
+            pyledger_id = match.group(1)
+    return pyledger_id
+
+
 class TaxCode(CashCtrlAccountingEntity):
     """Provides tax code accessors and mutators for CashCtrl."""
 
+    @staticmethod
+    def tax_payload(row: dict, id_map: dict, class_map: dict) -> dict:
+        """Build the nested tax/create or tax/update payload from a pyledger row."""
+        calc_type = "NET" if row["is_inclusive"] else "GROSS"
+
+        # `LEGACY_EXP` / `LEGACY_REV` are the multi-rung auto-pick rules CashCtrl
+        # used to apply pre-2.3 — the closest match to the 2.2 implicit behaviour
+        # the adapter relied on.
+        def component(account):
+            is_asset = class_map[account] == "ASSET"
+            rule = "LEGACY_EXP" if is_asset else "LEGACY_REV"
+            return {"code": "", "accountId": id_map[account],
+                    "calcType": calc_type, "applyRule": rule}
+
+        components = [component(row["account"])]
+        contra = row.get("contra")
+        if contra is not None and not pd.isna(contra):
+            components.append(component(contra))
+
+        return {
+            "code": cashctrl_tax_code(row["id"]),
+            "description": f"[{row['id']}]:{row['description']}",
+            "documentName": row["description"],
+            "isDisplayTaxRate": True,
+            "components": components,
+            "rates": [{"percentage": row["rate"] * 100}],
+        }
+
     def list(self, pandas: bool = True) -> pd.DataFrame | pl.DataFrame:
         tax_rates = to_polars(self._client.list_tax_rates())
+        if tax_rates.is_empty():
+            result = self.standardize(pl.DataFrame(), pandas=False)
+            if pandas:
+                return to_pandas(result, self._schema)
+            return result
         accounts = to_polars(self._client.list_accounts())
         account_map = dict(accounts.select("id", "number").iter_rows())
-        if not tax_rates["accountId"].is_in(list(account_map.keys())).all():
-            raise ValueError("Unknown 'accountId' in CashCtrl tax rates.")
-        result = pl.DataFrame({
-            "id": tax_rates["name"],
-            "description": tax_rates["documentName"],
-            "account": tax_rates["accountId"].replace_strict(
-                account_map, default=None
-            ),
-            "rate": tax_rates["percentage"] / 100,
-            "is_inclusive": ~tax_rates["isGrossCalcType"],
-        })
 
-        duplicates = result.filter(result["id"].is_duplicated())["id"].unique().to_list()
+        records = []
+        for row in tax_rates.iter_rows(named=True):
+            components = sorted(row["components"] or [], key=lambda c: c.get("pos", 0))
+            if not components:
+                raise ValueError(f"Tax code '{row['code']}' has no components.")
+
+            match = _DESCRIPTION_RE.match(str(row["description"] or ""))
+            if match:
+                pyledger_id, description = match.group(1), match.group(2)
+            else:
+                pyledger_id, description = row["code"], row["description"] or ""
+
+            percentage = row["currentPercentage"]
+            records.append({
+                "id": pyledger_id,
+                "account": account_map.get(components[0]["accountId"]),
+                "rate": (percentage if percentage is not None else 0) / 100,
+                "is_inclusive": components[0]["calcType"] == "NET",
+                "description": description,
+                "contra": account_map.get(components[1]["accountId"])
+                if len(components) > 1 else None,
+            })
+
+        result = pl.DataFrame(records)
+        duplicates = result.filter(pl.col("id").is_duplicated())["id"].unique().to_list()
         if duplicates:
             raise ValueError(
-                f"Duplicated tax codes in the remote system: '{', '.join(map(str, duplicates))}'"
+                f"Duplicated tax codes in the remote system: '{', '.join(map(str, duplicates))}'."
             )
         result = self.standardize(result, pandas=False)
 
@@ -43,16 +111,14 @@ class TaxCode(CashCtrlAccountingEntity):
         incoming = incoming.with_columns(
             is_inclusive=pl.col("is_inclusive").fill_null(False)
         )
+        accounts = to_polars(self._client.list_accounts())
+        id_map = dict(accounts.select("number", "id").iter_rows())
+        class_map = dict(accounts.select("number", "accountClass").iter_rows())
         for row in incoming.iter_rows(named=True):
-            self._client.account_to_id(row["account"])
-            payload = {
-                "name": row["id"],
-                "percentage": row["rate"] * 100,
-                "accountId": self._client.account_to_id(row["account"]),
-                "documentName": row["description"],
-                "calcType": "NET" if row["is_inclusive"] else "GROSS",
-            }
-            self._client.post("tax/create.json", data=payload)
+            self._client.post(
+                "tax/create.json",
+                data=self.tax_payload(row=row, id_map=id_map, class_map=class_map),
+            )
         self._client.list_tax_rates.cache_clear()
 
     def modify(self, data: pd.DataFrame | pl.DataFrame) -> None:
@@ -63,23 +129,17 @@ class TaxCode(CashCtrlAccountingEntity):
         reduced_schema = self._schema.filter(pl.col("column").is_in(cols))
         incoming = enforce_schema(data, reduced_schema, keep_extra_columns=True)
         current = self.list(pandas=False)
+        accounts = to_polars(self._client.list_accounts())
+        id_map = dict(accounts.select("number", "id").iter_rows())
+        class_map = dict(accounts.select("number", "accountClass").iter_rows())
 
         for row in incoming.iter_rows(named=True):
-            # Specify required fields for CashCtrl
-            existing = current.filter(pl.col("id") == row["id"])
-            rate = row["rate"] if "rate" in incoming.columns else existing["rate"][0]
-            account = row["account"] if "account" in incoming.columns else \
-                existing["account"][0]
-            payload = {"id": self._client.tax_code_to_id(row["id"])}
-            payload["name"] = row["id"]
-            payload["percentage"] = rate * 100
-            payload["accountId"] = self._client.account_to_id(account)
-
-            # Specify optional fields for CashCtrl
-            if "is_inclusive" in incoming.columns:
-                payload["calcType"] = "NET" if row["is_inclusive"] else "GROSS"
-            if "description" in incoming.columns:
-                payload["documentName"] = row["description"]
+            cashctrl_id = self._client.tax_code_to_id(code=cashctrl_tax_code(row["id"]))
+            merged = dict(current.filter(pl.col("id") == row["id"]).row(0, named=True))
+            for col in incoming.columns:
+                merged[col] = row[col]
+            payload = self.tax_payload(row=merged, id_map=id_map, class_map=class_map)
+            payload["id"] = cashctrl_id
             self._client.post("tax/update.json", data=payload)
         self._client.list_tax_rates.cache_clear()
 
@@ -90,9 +150,11 @@ class TaxCode(CashCtrlAccountingEntity):
         )
         ids = []
         for code in incoming["id"].to_list():
-            id = self._client.tax_code_to_id(code, allow_missing=allow_missing)
-            if id:
-                ids.append(str(id))
-        if len(ids):
+            cashctrl_id = self._client.tax_code_to_id(
+                code=cashctrl_tax_code(code), allow_missing=allow_missing
+            )
+            if cashctrl_id:
+                ids.append(str(cashctrl_id))
+        if ids:
             self._client.post("tax/delete.json", {"ids": ", ".join(ids)})
             self._client.list_tax_rates.cache_clear()

--- a/cashctrl_ledger/tests/test_tax_code_helpers.py
+++ b/cashctrl_ledger/tests/test_tax_code_helpers.py
@@ -1,0 +1,40 @@
+"""Unit tests for pure helpers in tax_code."""
+
+import pandas as pd
+import pytest
+from cashctrl_ledger.tax_code import cashctrl_tax_code, extract_pyledger_id
+
+
+@pytest.mark.parametrize("pyledger_id, expected", [
+    ("IN_STD", "INSTD"),
+    ("OUT_STD", "OUTSTD"),
+    ("IN-RED", "INRED"),
+    ("A.B.C", "ABC"),
+    ("EXEMPT", "EXEMPT"),
+    ("UN1", "UN1"),
+    ("tax 2.6%", "TAX26"),
+    ("", ""),
+])
+def test_cashctrl_tax_code(pyledger_id, expected):
+    assert cashctrl_tax_code(pyledger_id) == expected
+
+
+def test_extract_pyledger_id_with_prefix():
+    assert extract_pyledger_id("[IN_STD]:Input VAT 8.1%", "INSTD") == "IN_STD"
+
+
+def test_extract_pyledger_id_without_prefix_falls_back_to_code():
+    assert extract_pyledger_id("Input VAT 8.1%", "INSTD") == "INSTD"
+
+
+def test_extract_pyledger_id_with_null_description():
+    assert extract_pyledger_id(None, "INSTD") == "INSTD"
+    assert extract_pyledger_id(pd.NA, "INSTD") == "INSTD"
+
+
+def test_extract_pyledger_id_preserves_non_alphanumeric_original():
+    assert extract_pyledger_id("[OUT_RED]:foo", "OUTRED") == "OUT_RED"
+
+
+def test_extract_pyledger_id_only_matches_leading_bracket():
+    assert extract_pyledger_id("Input VAT [5%]:note", "INSTD") == "INSTD"


### PR DESCRIPTION
Polars port of #146. Brings the long-lived `polars` branch into parity with `main` after the CashCtrl API 2.3.0 tax-system overhaul. Without this, the `polars` branch is broken against the current `cashctrl_api/main` (which already ships the new `taxCode`/`components[]`/`currentPercentage` shape via the tarball pin in `setup.py`).

Replaces #147 — same content, branch renamed to satisfy the CI workflow's `polars-*` head-branch heuristic.

## Scope

Behavioural parity with #146 (commit `bd5b99b`) — no logic changes, only polars idioms substituted for pandas equivalents at the dataframe layer.

- **`cashctrl_ledger/tax_code.py`** — adds `cashctrl_tax_code()` (alphanumeric sanitizer for ids like `IN_STD` → `INSTD`) and `extract_pyledger_id()` (recovers original id from `[id]:...` description prefix). Adds `tax_payload()` static builder. `list()` unwraps `components[]` (sorted by `pos`) for `account`/`contra` and reads `currentPercentage`; empty-rates early return added. `add()` / `modify()` build one- or two-element `components[]` payloads with `applyRule = LEGACY_EXP`/`LEGACY_REV` derived from each component account's class (matches what landed on `main`). Pyledger `contra` round-trips via `components[1]`. `delete()` sanitizes ids before resolving.
- **`cashctrl_ledger/accounts.py`** — `Account.list()` reads the renamed `taxCode` field; reverse-maps to the original pyledger id via `extract_pyledger_id`. `add` / `modify` sanitize the pyledger `tax_code` before `tax_code_to_id`. Uses polars `Series.replace(dict)` (keeps non-matched values intact, matching the pandas `.map().fillna(original)` pattern).
- **`cashctrl_ledger/ledger.py`** — `_map_journal_entries` builds the same reverse map and applies it to `taxCode` reads on individual + collective entries. Journal write paths sanitize before `tax_code_to_id`.
- **`cashctrl_ledger/constants.py`** — `JOURNAL_ITEM_COLUMNS`: `taxName` → `taxCode`.
- **Tests** — `test_tax_code_helpers.py` (13 cases) copied verbatim from `main`. Pure-Python, no network.

## Validation

- flake8 clean across changed files.
- `test_tax_code_helpers.py`: 13/13 pass.
- Offline smoke tests against mocked `_client`: `tax_payload()` (single-component asset → `LEGACY_EXP`, liability → `LEGACY_REV`, two-component contra round-trip, null-contra single component); `TaxCode.list()` (description-prefix unwrapping, `pos`-sorted components, empty-rates early return, both `pandas=True/False`); `Account.list()` (reverse-mapping with prefix-bearing and prefix-less codes, null tax_code preservation, empty-rates noop).
- Integration suite (`test_tax_codes.py`, etc.) runs in CI against the test tenant. Should mirror the `115 passed, 5 skipped` from #146's validation.

## Notes

- `test_tax_codes.py` was already converted to polars in `73a49f6` and #146 didn't touch it, so left untouched here.
- The *production* logic diff matches #146 exactly modulo idiom translation.